### PR TITLE
Replace AVAudioPlayer with AVAudioEngine

### DIFF
--- a/Application/AppDelegate.swift
+++ b/Application/AppDelegate.swift
@@ -40,7 +40,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             coordinator.savePlaybackState()
 
             // Stop the playback
-            coordinator.audioPlayerManager.stopGracefully()
+            coordinator.playbackManager.stopGracefully()
             
             // Force a database checkpoint to ensure all data is persisted
             coordinator.libraryManager.databaseManager.checkpoint()
@@ -136,7 +136,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.autoenablesItems = false
         
         guard let coordinator = AppCoordinator.shared else { return menu }
-        let audioPlayerManager = coordinator.audioPlayerManager
+        let playbackManager = coordinator.playbackManager
         let playlistManager = coordinator.playlistManager
         
         // Now Playing header
@@ -144,7 +144,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         nowPlayingItem.isEnabled = false
         menu.addItem(nowPlayingItem)
         
-        if let currentTrack = audioPlayerManager.currentTrack {
+        if let currentTrack = playbackManager.currentTrack {
             // Song title
             let titleItem = NSMenuItem(title: "  \(currentTrack.title)", action: nil, keyEquivalent: "")
             titleItem.isEnabled = false
@@ -225,14 +225,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem.separator())
         
         // Playback controls
-        let playPauseTitle = audioPlayerManager.isPlaying ? "Pause" : "Play"
+        let playPauseTitle = playbackManager.isPlaying ? "Pause" : "Play"
         let playPauseItem = NSMenuItem(
             title: playPauseTitle,
             action: #selector(togglePlayPause),
             keyEquivalent: ""
         )
         playPauseItem.target = self
-        playPauseItem.isEnabled = audioPlayerManager.currentTrack != nil
+        playPauseItem.isEnabled = playbackManager.currentTrack != nil
         menu.addItem(playPauseItem)
         
         let nextItem = NSMenuItem(
@@ -241,7 +241,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             keyEquivalent: ""
         )
         nextItem.target = self
-        nextItem.isEnabled = audioPlayerManager.currentTrack != nil
+        nextItem.isEnabled = playbackManager.currentTrack != nil
         menu.addItem(nextItem)
 
         let previousItem = NSMenuItem(
@@ -250,7 +250,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             keyEquivalent: ""
         )
         previousItem.target = self
-        previousItem.isEnabled = audioPlayerManager.currentTrack != nil
+        previousItem.isEnabled = playbackManager.currentTrack != nil
         menu.addItem(previousItem)
         
         return menu
@@ -261,7 +261,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc
     private func toggleFavorite() {
         guard let coordinator = AppCoordinator.shared,
-              let track = coordinator.audioPlayerManager.currentTrack else { return }
+              let track = coordinator.playbackManager.currentTrack else { return }
         
         coordinator.playlistManager.toggleFavorite(for: track)
     }
@@ -288,7 +288,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     @objc
     private func togglePlayPause() {
-        AppCoordinator.shared?.audioPlayerManager.togglePlayPause()
+        AppCoordinator.shared?.playbackManager.togglePlayPause()
     }
     
     @objc

--- a/Managers/MenuBarManager.swift
+++ b/Managers/MenuBarManager.swift
@@ -10,15 +10,15 @@ import SwiftUI
 
 class MenuBarManager: NSObject {
     private var statusItem: NSStatusItem?
-    private let audioPlayerManager: AudioPlayerManager
+    private let playbackManager: PlaybackManager
     private let playlistManager: PlaylistManager
 
     var isMenuBarActive: Bool {
         statusItem != nil
     }
 
-    init(audioPlayerManager: AudioPlayerManager, playlistManager: PlaylistManager) {
-        self.audioPlayerManager = audioPlayerManager
+    init(playbackManager: PlaybackManager, playlistManager: PlaylistManager) {
+        self.playbackManager = playbackManager
         self.playlistManager = playlistManager
         super.init()
 
@@ -73,7 +73,7 @@ class MenuBarManager: NSObject {
         guard let button = statusItem?.button else { return }
 
         // Use play/pause circle icons based on playback state
-        let iconName = audioPlayerManager.isPlaying ? Icons.playCircleFill : Icons.pauseCircleFill
+        let iconName = playbackManager.isPlaying ? Icons.playCircleFill : Icons.pauseCircleFill
 
         if let image = NSImage(systemSymbolName: iconName, accessibilityDescription: "Petrichor") {
             image.size = NSSize(width: 18, height: 18)
@@ -102,7 +102,7 @@ class MenuBarManager: NSObject {
 
         // Play/Pause
         let playPauseItem = NSMenuItem(
-            title: audioPlayerManager.isPlaying ? "Pause" : "Play",
+            title: playbackManager.isPlaying ? "Pause" : "Play",
             action: #selector(togglePlayPause),
             keyEquivalent: ""
         )
@@ -174,7 +174,7 @@ class MenuBarManager: NSObject {
 
     @objc
     private func togglePlayPause() {
-        audioPlayerManager.togglePlayPause()
+        playbackManager.togglePlayPause()
         updateMenu()
     }
 

--- a/Managers/NowPlayingManager.swift
+++ b/Managers/NowPlayingManager.swift
@@ -58,7 +58,7 @@ class NowPlayingManager {
         commandCenter.changePlaybackPositionCommand.removeTarget(nil)
     }
 
-    func connectRemoteCommandCenter(audioPlayer: AudioPlayerManager, playlistManager: PlaylistManager) {
+    func connectRemoteCommandCenter(audioPlayer: PlaybackManager, playlistManager: PlaylistManager) {
         let commandCenter = MPRemoteCommandCenter.shared()
 
         // Add handler for play command

--- a/Managers/PlaybackManager.swift
+++ b/Managers/PlaybackManager.swift
@@ -1,5 +1,5 @@
 //
-// AudioPlayerManager class
+// PlaybackManager class
 //
 // This class handles the track playback, including progression update,
 // seeking, and playback state management.
@@ -8,7 +8,7 @@
 import AVFoundation
 import Foundation
 
-class AudioPlayerManager: NSObject, ObservableObject, AVAudioPlayerDelegate {
+class PlaybackManager: NSObject, ObservableObject, AVAudioPlayerDelegate {
     @Published var currentTrack: Track?
     @Published var isPlaying: Bool = false {
         didSet {

--- a/Managers/Playlist/PMPlayback.swift
+++ b/Managers/Playlist/PMPlayback.swift
@@ -2,7 +2,7 @@
 // PlaylistManager class extension
 //
 // This extension contains methods for handling track playback,
-// the methods internally also use AudioPlayerManager methods to work with AVFoundation along
+// the methods internally also use PlaybackManager methods to work with AVFoundation along
 // with DatabaseManager methods.
 //
 

--- a/Managers/Playlist/PlaylistManager.swift
+++ b/Managers/Playlist/PlaylistManager.swift
@@ -28,14 +28,14 @@ class PlaylistManager: ObservableObject {
     internal var libraryManager: LibraryManager?
 
     // MARK: - Dependencies
-    internal weak var audioPlayer: AudioPlayerManager?
+    internal weak var audioPlayer: PlaybackManager?
 
     // MARK: - Initialization
     init() {
         // Don't load playlists yet - wait until libraryManager is set
     }
 
-    func setAudioPlayer(_ player: AudioPlayerManager) {
+    func setAudioPlayer(_ player: PlaybackManager) {
         self.audioPlayer = player
     }
 

--- a/PetrichorApp.swift
+++ b/PetrichorApp.swift
@@ -13,13 +13,13 @@ struct PetrichorApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environmentObject(appCoordinator.audioPlayerManager)
+                .environmentObject(appCoordinator.playbackManager)
                 .environmentObject(appCoordinator.libraryManager)
                 .environmentObject(appCoordinator.playlistManager)
                 .onReceive(appCoordinator.playlistManager.$repeatMode) { _ in
                     menuUpdateTrigger = UUID()
                 }
-                .onReceive(appCoordinator.audioPlayerManager.$currentTrack) { _ in
+                .onReceive(appCoordinator.playbackManager.$currentTrack) { _ in
                     menuUpdateTrigger = UUID()
                 }
         }
@@ -52,21 +52,21 @@ struct PetrichorApp: App {
             
             CommandMenu("Playback") {
                 Button("Play/Pause") {
-                    if appCoordinator.audioPlayerManager.currentTrack != nil {
-                        appCoordinator.audioPlayerManager.togglePlayPause()
+                    if appCoordinator.playbackManager.currentTrack != nil {
+                        appCoordinator.playbackManager.togglePlayPause()
                     }
                 }
                 .keyboardShortcut(" ", modifiers: [])
-                .disabled(appCoordinator.audioPlayerManager.currentTrack == nil)
+                .disabled(appCoordinator.playbackManager.currentTrack == nil)
                 
-                Button(appCoordinator.audioPlayerManager.currentTrack?.isFavorite == true ? "Remove from Favorites" : "Add to Favorites") {
-                    if let track = appCoordinator.audioPlayerManager.currentTrack {
+                Button(appCoordinator.playbackManager.currentTrack?.isFavorite == true ? "Remove from Favorites" : "Add to Favorites") {
+                    if let track = appCoordinator.playbackManager.currentTrack {
                         appCoordinator.playlistManager.toggleFavorite(for: track)
                         menuUpdateTrigger = UUID()
                     }
                 }
                 .keyboardShortcut("f", modifiers: [.command, .shift])
-                .disabled(appCoordinator.audioPlayerManager.currentTrack == nil)
+                .disabled(appCoordinator.playbackManager.currentTrack == nil)
                 .id(menuUpdateTrigger)
                 
                 Divider()
@@ -89,43 +89,43 @@ struct PetrichorApp: App {
                     appCoordinator.playlistManager.playNextTrack()
                 }
                 .keyboardShortcut(.rightArrow, modifiers: .command)
-                .disabled(appCoordinator.audioPlayerManager.currentTrack == nil)
+                .disabled(appCoordinator.playbackManager.currentTrack == nil)
                 
                 Button("Previous") {
                     appCoordinator.playlistManager.playPreviousTrack()
                 }
                 .keyboardShortcut(.leftArrow, modifiers: .command)
-                .disabled(appCoordinator.audioPlayerManager.currentTrack == nil)
+                .disabled(appCoordinator.playbackManager.currentTrack == nil)
                 
                 Button("Seek Forward") {
-                    if let currentTrack = appCoordinator.audioPlayerManager.currentTrack {
-                        let newTime = min(appCoordinator.audioPlayerManager.currentTime + 10, currentTrack.duration)
-                        appCoordinator.audioPlayerManager.seekTo(time: newTime)
+                    if let currentTrack = appCoordinator.playbackManager.currentTrack {
+                        let newTime = min(appCoordinator.playbackManager.actualCurrentTime + 10, currentTrack.duration)
+                        appCoordinator.playbackManager.seekTo(time: newTime)
                     }
                 }
                 .keyboardShortcut(.rightArrow, modifiers: [])
-                .disabled(appCoordinator.audioPlayerManager.currentTrack == nil)
+                .disabled(appCoordinator.playbackManager.currentTrack == nil)
                 
                 Button("Seek Backward") {
-                    if appCoordinator.audioPlayerManager.currentTrack != nil {
-                        let newTime = max(appCoordinator.audioPlayerManager.currentTime - 10, 0)
-                        appCoordinator.audioPlayerManager.seekTo(time: newTime)
+                    if appCoordinator.playbackManager.currentTrack != nil {
+                        let newTime = max(appCoordinator.playbackManager.actualCurrentTime - 10, 0)
+                        appCoordinator.playbackManager.seekTo(time: newTime)
                     }
                 }
                 .keyboardShortcut(.leftArrow, modifiers: [])
-                .disabled(appCoordinator.audioPlayerManager.currentTrack == nil)
+                .disabled(appCoordinator.playbackManager.currentTrack == nil)
                 
                 Divider()
                 
                 Button("Volume Up") {
-                    let newVolume = min(appCoordinator.audioPlayerManager.volume + 0.05, 1.0)
-                    appCoordinator.audioPlayerManager.setVolume(newVolume)
+                    let newVolume = min(appCoordinator.playbackManager.volume + 0.05, 1.0)
+                    appCoordinator.playbackManager.setVolume(newVolume)
                 }
                 .keyboardShortcut(.upArrow, modifiers: [])
                 
                 Button("Volume Down") {
-                    let newVolume = max(appCoordinator.audioPlayerManager.volume - 0.05, 0.0)
-                    appCoordinator.audioPlayerManager.setVolume(newVolume)
+                    let newVolume = max(appCoordinator.playbackManager.volume - 0.05, 0.0)
+                    appCoordinator.playbackManager.setVolume(newVolume)
                 }
                 .keyboardShortcut(.downArrow, modifiers: [])
             }

--- a/Utilities/Constants.swift
+++ b/Utilities/Constants.swift
@@ -78,6 +78,7 @@ enum About {
     static let appSubtitle = "An offline macOS music player"
     static let appWebsite = "https://github.com/kushalpandya/Petrichor"
     static let appWiki = "https://github.com/kushalpandya/Petrichor/wiki"
+    static let appPlaybackQueueLabel = "org.Petrichor.playback"
 }
 
 // MARK: - Audio File Formats
@@ -117,6 +118,8 @@ enum AnimationDuration {
 enum TimeConstants {
     static let fiftyMilliseconds: UInt64 = 50_000_000
     static let oneFiftyMilliseconds: UInt64 = 150_000_000
+    static let stateSaveTimerDuration: Double = 30.0
+    static let playbackProgressTimerDuration: Double = 5.0
 }
 
 // MARK: - Database Constants

--- a/Views/Components/TrackView.swift
+++ b/Views/Components/TrackView.swift
@@ -9,7 +9,7 @@ struct TrackView: View {
     let onPlayTrack: (Track) -> Void
     let contextMenuItems: (Track) -> [ContextMenuItem]
 
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
 
     var body: some View {
         switch viewType {
@@ -99,7 +99,7 @@ struct TrackContextMenuContent: View {
         contextMenuItems: { _ in [] }
     )
     .frame(height: 400)
-    .environmentObject(AudioPlayerManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
+    .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
 }
 
 #Preview("Grid View") {
@@ -124,7 +124,7 @@ struct TrackContextMenuContent: View {
         contextMenuItems: { _ in [] }
     )
     .frame(height: 600)
-    .environmentObject(AudioPlayerManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
+    .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
 }
 
 #Preview("Table View") {
@@ -151,7 +151,7 @@ struct TrackContextMenuContent: View {
         contextMenuItems: { _ in [] }
     )
     .frame(height: 600)
-    .environmentObject(AudioPlayerManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
+    .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
 }
 
 #Preview("Table View with Playlist") {
@@ -178,5 +178,5 @@ struct TrackContextMenuContent: View {
         contextMenuItems: { _ in [] }
     )
     .frame(height: 600)
-    .environmentObject(AudioPlayerManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
+    .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
 }

--- a/Views/Components/TrackViews/TrackGridView.swift
+++ b/Views/Components/TrackViews/TrackGridView.swift
@@ -5,7 +5,7 @@ struct TrackGridView: View {
     let onPlayTrack: (Track) -> Void
     let contextMenuItems: (Track) -> [ContextMenuItem]
 
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @State private var gridWidth: CGFloat = 0
     @State private var visibleRange: Range<Int> = 0..<0
 
@@ -30,7 +30,7 @@ struct TrackGridView: View {
                             TrackGridItem(
                                 track: track
                             ) {
-                                    let isCurrentTrack = audioPlayerManager.currentTrack?.url.path == track.url.path
+                                    let isCurrentTrack = playbackManager.currentTrack?.url.path == track.url.path
                                     if !isCurrentTrack {
                                         onPlayTrack(track)
                                     }
@@ -73,18 +73,18 @@ private struct TrackGridItem: View {
     @ObservedObject var track: Track
     let onPlay: () -> Void
 
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @State private var isHovered = false
     @State private var artworkImage: NSImage?
     @State private var artworkLoadTask: Task<Void, Never>?
 
     private var isCurrentTrack: Bool {
-        guard let currentTrack = audioPlayerManager.currentTrack else { return false }
+        guard let currentTrack = playbackManager.currentTrack else { return false }
         return currentTrack.url.path == track.url.path
     }
 
     private var isPlaying: Bool {
-        isCurrentTrack && audioPlayerManager.isPlaying
+        isCurrentTrack && playbackManager.isPlaying
     }
 
     var body: some View {
@@ -159,7 +159,7 @@ private struct TrackGridItem: View {
             .overlay(
                 Button(action: {
                     if isCurrentTrack {
-                        audioPlayerManager.togglePlayPause()
+                        playbackManager.togglePlayPause()
                     } else {
                         onPlay()
                     }

--- a/Views/Components/TrackViews/TrackListView.swift
+++ b/Views/Components/TrackViews/TrackListView.swift
@@ -5,7 +5,7 @@ struct TrackListView: View {
     let onPlayTrack: (Track) -> Void
     let contextMenuItems: (Track) -> [ContextMenuItem]
 
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @State private var hoveredTrackID: UUID?
 
     var body: some View {
@@ -16,7 +16,7 @@ struct TrackListView: View {
                         track: track,
                         isHovered: hoveredTrackID == track.id,
                         onPlay: {
-                            let isCurrentTrack = audioPlayerManager.currentTrack?.url.path == track.url.path
+                            let isCurrentTrack = playbackManager.currentTrack?.url.path == track.url.path
                             if !isCurrentTrack {
                                 onPlayTrack(track)
                             }
@@ -43,7 +43,7 @@ private struct TrackListRow: View {
     let onPlay: () -> Void
     let onHover: (Bool) -> Void
 
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @State private var artworkImage: NSImage?
 
     var body: some View {
@@ -61,12 +61,12 @@ private struct TrackListRow: View {
     // MARK: - Computed Properties
 
     private var isCurrentTrack: Bool {
-        guard let currentTrack = audioPlayerManager.currentTrack else { return false }
+        guard let currentTrack = playbackManager.currentTrack else { return false }
         return currentTrack.url.path == track.url.path
     }
 
     private var isPlaying: Bool {
-        isCurrentTrack && audioPlayerManager.isPlaying
+        isCurrentTrack && playbackManager.isPlaying
     }
 
     // MARK: - View Components
@@ -207,7 +207,7 @@ private struct TrackListRow: View {
         // Show button if:
         // 1. Hovered (play or pause depending on state)
         // 2. Current track but paused (persistent play button)
-        isHovered || (isCurrentTrack && !audioPlayerManager.isPlaying)
+        isHovered || (isCurrentTrack && !playbackManager.isPlaying)
     }
 
     private var playButtonIcon: String {
@@ -243,7 +243,7 @@ private struct TrackListRow: View {
 
     private func handlePlayButtonTap() {
         if isCurrentTrack {
-            audioPlayerManager.togglePlayPause()
+            playbackManager.togglePlayPause()
         } else {
             onPlay()
         }

--- a/Views/Folders/FoldersView.swift
+++ b/Views/Folders/FoldersView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import Foundation
 
 struct FoldersView: View {
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @EnvironmentObject var libraryManager: LibraryManager
     @EnvironmentObject var playlistManager: PlaylistManager
     @State private var selectedFolderNode: FolderNode?
@@ -162,7 +162,7 @@ struct FoldersView: View {
                     if let dbFolder = node.databaseFolder {
                         return TrackContextMenu.createMenuItems(
                             for: track,
-                            audioPlayerManager: audioPlayerManager,
+                            playbackManager: playbackManager,
                             playlistManager: playlistManager,
                             currentContext: .folder(dbFolder)
                         )
@@ -170,7 +170,7 @@ struct FoldersView: View {
                         // For sub-folders, use library context
                         return TrackContextMenu.createMenuItems(
                             for: track,
-                            audioPlayerManager: audioPlayerManager,
+                            playbackManager: playbackManager,
                             playlistManager: playlistManager,
                             currentContext: .library
                         )
@@ -291,7 +291,7 @@ struct FoldersView: View {
     FoldersView(viewType: .list)
         .environmentObject({
             let coordinator = AppCoordinator()
-            return coordinator.audioPlayerManager
+            return coordinator.playbackManager
         }())
         .environmentObject({
             let coordinator = AppCoordinator()

--- a/Views/Home/EntityDetailView.swift
+++ b/Views/Home/EntityDetailView.swift
@@ -8,7 +8,7 @@ struct EntityDetailView: View {
     let viewType: LibraryViewType
     let onBack: (() -> Void)?
     
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @EnvironmentObject var playlistManager: PlaylistManager
     @EnvironmentObject var libraryManager: LibraryManager
     @State private var tracks: [Track] = []
@@ -40,7 +40,7 @@ struct EntityDetailView: View {
                     contextMenuItems: { track in
                         TrackContextMenu.createMenuItems(
                             for: track,
-                            audioPlayerManager: audioPlayerManager,
+                            playbackManager: playbackManager,
                             playlistManager: playlistManager,
                             currentContext: .library
                         )
@@ -364,7 +364,7 @@ struct EntityDetailView: View {
         viewType: .list
     ) { Logger.debugPrint("Back tapped") }
     .environmentObject(LibraryManager())
-    .environmentObject(AudioPlayerManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
+    .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
     .environmentObject(PlaylistManager())
     .frame(height: 600)
 }
@@ -377,7 +377,7 @@ struct EntityDetailView: View {
         viewType: .grid
     ) { Logger.debugPrint("Back tapped") }
     .environmentObject(LibraryManager())
-    .environmentObject(AudioPlayerManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
+    .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
     .environmentObject(PlaylistManager())
     .frame(height: 600)
 }

--- a/Views/Home/HomeView.swift
+++ b/Views/Home/HomeView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct HomeView: View {
     @EnvironmentObject var libraryManager: LibraryManager
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @EnvironmentObject var playlistManager: PlaylistManager
     
     @AppStorage("trackListSortAscending")
@@ -183,7 +183,7 @@ struct HomeView: View {
                     contextMenuItems: { track in
                         TrackContextMenu.createMenuItems(
                             for: track,
-                            audioPlayerManager: audioPlayerManager,
+                            playbackManager: playbackManager,
                             playlistManager: playlistManager,
                             currentContext: .library
                         )
@@ -405,7 +405,7 @@ struct HomeView: View {
                             contextMenuItems: { track in
                                 TrackContextMenu.createMenuItems(
                                     for: track,
-                                    audioPlayerManager: audioPlayerManager,
+                                    playbackManager: playbackManager,
                                     playlistManager: playlistManager,
                                     currentContext: .library
                                 )
@@ -506,7 +506,7 @@ struct HomeView: View {
     
     HomeView(isShowingEntities: $isShowingEntities)
         .environmentObject(LibraryManager())
-        .environmentObject(AudioPlayerManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
+        .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
         .environmentObject(PlaylistManager())
         .frame(width: 800, height: 600)
 }

--- a/Views/Library/LibraryView.swift
+++ b/Views/Library/LibraryView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct LibraryView: View {
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @EnvironmentObject var libraryManager: LibraryManager
     @EnvironmentObject var playlistManager: PlaylistManager
 
@@ -140,7 +140,7 @@ struct LibraryView: View {
                     contextMenuItems: { track in
                         TrackContextMenu.createMenuItems(
                             for: track,
-                            audioPlayerManager: audioPlayerManager,
+                            playbackManager: playbackManager,
                             playlistManager: playlistManager,
                             currentContext: .library
                         )
@@ -255,7 +255,7 @@ struct LibraryView: View {
     private func createLibraryContextMenu(for track: Track) -> [ContextMenuItem] {
         TrackContextMenu.createMenuItems(
             for: track,
-            audioPlayerManager: audioPlayerManager,
+            playbackManager: playbackManager,
             playlistManager: playlistManager,
             currentContext: .library
         )
@@ -310,7 +310,7 @@ struct LibraryView: View {
     LibraryView(viewType: .list)
         .environmentObject({
             let coordinator = AppCoordinator()
-            return coordinator.audioPlayerManager
+            return coordinator.playbackManager
         }())
         .environmentObject({
             let coordinator = AppCoordinator()

--- a/Views/Main/ContentView.swift
+++ b/Views/Main/ContentView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ContentView: View {
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @EnvironmentObject var libraryManager: LibraryManager
     @EnvironmentObject var playlistManager: PlaylistManager
 
@@ -69,11 +69,11 @@ struct ContentView: View {
             pendingLibraryFilter: $pendingLibraryFilter,
             showTrackDetail: showTrackDetail
         )
-        .onChange(of: audioPlayerManager.currentTrack?.id) { oldId, _ in
+        .onChange(of: playbackManager.currentTrack?.id) { oldId, _ in
             if showingTrackDetail,
                let detailTrack = detailTrack,
                detailTrack.id == oldId,
-               let newTrack = audioPlayerManager.currentTrack {
+               let newTrack = playbackManager.currentTrack {
                 self.detailTrack = newTrack
             }
         }
@@ -360,7 +360,7 @@ class WindowManager {
     ContentView()
         .environmentObject({
             let coordinator = AppCoordinator()
-            return coordinator.audioPlayerManager
+            return coordinator.playbackManager
         }())
         .environmentObject({
             let coordinator = AppCoordinator()

--- a/Views/Main/PlayQueueView.swift
+++ b/Views/Main/PlayQueueView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct PlayQueueView: View {
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @EnvironmentObject var playlistManager: PlaylistManager
     @State private var draggedTrack: Track?
     @State private var showingClearConfirmation = false
@@ -151,7 +151,7 @@ struct PlayQueueView: View {
             track: track,
             position: index,
             isCurrentTrack: index == playlistManager.currentQueueIndex,
-            isPlaying: index == playlistManager.currentQueueIndex && audioPlayerManager.isPlaying,
+            isPlaying: index == playlistManager.currentQueueIndex && playbackManager.isPlaying,
             playlistManager: playlistManager
         ) {
                 playlistManager.removeFromQueue(at: index)
@@ -354,11 +354,11 @@ struct QueueDropDelegate: DropDelegate {
     
     return PlayQueueView(showingQueue: $showingQueue)
         .environmentObject({
-            let audioPlayerManager = AudioPlayerManager(
+            let playbackManager = PlaybackManager(
                 libraryManager: LibraryManager(),
                 playlistManager: PlaylistManager()
             )
-            return audioPlayerManager
+            return playbackManager
         }())
         .environmentObject({
             let playlistManager = PlaylistManager()
@@ -383,11 +383,11 @@ struct QueueDropDelegate: DropDelegate {
     
     return PlayQueueView(showingQueue: $showingQueue)
         .environmentObject({
-            let audioPlayerManager = AudioPlayerManager(
+            let playbackManager = PlaybackManager(
                 libraryManager: LibraryManager(),
                 playlistManager: PlaylistManager()
             )
-            return audioPlayerManager
+            return playbackManager
         }())
         .environmentObject(PlaylistManager())
         .frame(width: 350, height: 600)

--- a/Views/Playlists/PlaylistDetailView.swift
+++ b/Views/Playlists/PlaylistDetailView.swift
@@ -4,7 +4,7 @@ struct PlaylistDetailView: View {
     let playlistID: UUID
     let viewType: LibraryViewType
 
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @EnvironmentObject var playlistManager: PlaylistManager
     @StateObject private var playlistSortManager = PlaylistSortManager.shared
     @State private var selectedTrackID: UUID?
@@ -225,7 +225,7 @@ struct PlaylistDetailView: View {
                         if let playlist = playlist {
                             return TrackContextMenu.createMenuItems(
                                 for: track,
-                                audioPlayerManager: audioPlayerManager,
+                                playbackManager: playbackManager,
                                 playlistManager: playlistManager,
                                 currentContext: .playlist(playlist)
                             )
@@ -432,7 +432,7 @@ struct PlaylistDetailView: View {
         }())
         .environmentObject({
             let coordinator = AppCoordinator()
-            return coordinator.audioPlayerManager
+            return coordinator.playbackManager
         }())
         .frame(height: 600)
 }
@@ -460,7 +460,7 @@ struct PlaylistDetailView: View {
         }())
         .environmentObject({
             let coordinator = AppCoordinator()
-            return coordinator.audioPlayerManager
+            return coordinator.playbackManager
         }())
         .frame(height: 600)
 }

--- a/Views/Playlists/PlaylistsView.swift
+++ b/Views/Playlists/PlaylistsView.swift
@@ -4,7 +4,7 @@ struct PlaylistsView: View {
     let viewType: LibraryViewType
 
     @EnvironmentObject var playlistManager: PlaylistManager
-    @EnvironmentObject var audioPlayerManager: AudioPlayerManager
+    @EnvironmentObject var playbackManager: PlaybackManager
     @EnvironmentObject var libraryManager: LibraryManager
     @State private var selectedPlaylist: Playlist?
 
@@ -75,7 +75,7 @@ struct PlaylistsView: View {
         }())
         .environmentObject({
             let coordinator = AppCoordinator()
-            return coordinator.audioPlayerManager
+            return coordinator.playbackManager
         }())
         .environmentObject(LibraryManager())
         .frame(width: 800, height: 600)
@@ -89,7 +89,7 @@ struct PlaylistsView: View {
         }())
         .environmentObject({
             let coordinator = AppCoordinator()
-            return coordinator.audioPlayerManager
+            return coordinator.playbackManager
         }())
         .environmentObject(LibraryManager())
         .frame(width: 800, height: 600)

--- a/Views/Settings/LibraryTabView.swift
+++ b/Views/Settings/LibraryTabView.swift
@@ -334,7 +334,7 @@ struct LibraryTabView: View {
     private func resetLibraryData() {
         // Stop any current playback
         if let coordinator = AppCoordinator.shared {
-            coordinator.audioPlayerManager.stop()
+            coordinator.playbackManager.stop()
             coordinator.playlistManager.clearQueue()
         }
 


### PR DESCRIPTION
# Summary

Replaces `AVAudioPlayer` (and AudioPlayerManager class) with `AVAudioEngine` (with PlaybackManager class), this lays the foundation for EQ support in a future release, as well as better control over the audio pipeline.