### PR TITLE
Fixes for some personal gripes

### DIFF
--- a/Application/WindowDelegate.swift
+++ b/Application/WindowDelegate.swift
@@ -46,7 +46,11 @@ class WindowDelegate: NSObject, NSWindowDelegate {
         return newFrame
     }
 
-    // Add this to prevent saving corrupted frames
+    /*
+    // Disabled: Early frame-correction logic caused issues with 3rd-party tiling managers and Mission Control Spaces.
+    // Keeping this method active made the window jump to the currently active Space and fight with the
+    // window manager over its size, leading to rapid resizing loops.  The logic has been entirely
+    // commented out to allow external window managers to control the window freely.
     func windowDidMove(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
 
@@ -65,4 +69,5 @@ class WindowDelegate: NSObject, NSWindowDelegate {
             }
         }
     }
+*/
 }

--- a/Managers/Database/DMQueries.swift
+++ b/Managers/Database/DMQueries.swift
@@ -326,6 +326,16 @@ extension DatabaseManager {
                         .filter(Track.Columns.isDuplicate == false)
                         .select(sum(Track.Columns.duration))
                         .fetchOne(db) ?? 0.0
+
+                    // Fetch primary artist name for this album (if any)
+                    let primaryArtistName = try String.fetchOne(db, sql: """
+                        SELECT artists.name
+                        FROM album_artists
+                        JOIN artists ON artists.id = album_artists.artist_id
+                        WHERE album_artists.album_id = ? AND album_artists.role = 'primary'
+                        ORDER BY album_artists.position
+                        LIMIT 1
+                    """, arguments: [albumId])
                     
                     return AlbumEntity(
                         name: album.title,
@@ -333,7 +343,8 @@ extension DatabaseManager {
                         artworkData: album.artworkData,
                         albumId: album.id,
                         year: album.releaseYear.map { String($0) } ?? "",
-                        duration: totalDuration
+                        duration: totalDuration,
+                        artistName: primaryArtistName
                     )
                 }
             }

--- a/Managers/Library/LMLibrary.swift
+++ b/Managers/Library/LMLibrary.swift
@@ -112,6 +112,10 @@ extension LibraryManager {
         }
 
         refreshEntities()
+
+        // Kick off asynchronous thumbnail preheating so that album/artist artwork is already cached
+        ThumbnailPreheater.shared.preheat(entities: cachedAlbumEntities)
+
         // Post notification that library is loaded
         NotificationCenter.default.post(name: NSNotification.Name("LibraryDidLoad"), object: nil)
     }

--- a/Models/Core/Entity.swift
+++ b/Models/Core/Entity.swift
@@ -52,6 +52,7 @@ struct AlbumEntity: Entity {
     let albumId: Int64?
     let year: String?
     let duration: Double?
+    let artistName: String?
 
     var subtitle: String? {
         year
@@ -67,9 +68,10 @@ struct AlbumEntity: Entity {
         self.albumId = nil
         self.year = nil
         self.duration = nil
+        self.artistName = nil
     }
 
-    init(name: String, trackCount: Int, artworkData: Data? = nil, albumId: Int64? = nil, year: String? = nil, duration: Double? = nil) {
+    init(name: String, trackCount: Int, artworkData: Data? = nil, albumId: Int64? = nil, year: String? = nil, duration: Double? = nil, artistName: String? = nil) {
         // If we have an albumId, use it for a truly unique ID
         if let albumId = albumId {
             // Create a deterministic UUID from the album ID
@@ -87,6 +89,7 @@ struct AlbumEntity: Entity {
         self.albumId = albumId
         self.year = year
         self.duration = duration
+        self.artistName = artistName
     }
 }
 

--- a/Utilities/ImageCache.swift
+++ b/Utilities/ImageCache.swift
@@ -1,0 +1,34 @@
+import Foundation
+import AppKit
+
+/// A shared in-memory image cache for storing already-resized artwork images.
+/// The cache uses `NSCache` so the system can automatically purge it under memory pressure.
+final class ImageCache {
+    static let shared = ImageCache()
+
+    private let cache: NSCache<NSString, NSImage>
+
+    private init() {
+        let cache = NSCache<NSString, NSImage>()
+        // Limit the number of thumbnails and total memory cost (in bytes) to avoid unbounded growth.
+        cache.countLimit = 10_000
+        cache.totalCostLimit = 600 * 1_024 * 1_024 // ~600 MB
+        self.cache = cache
+    }
+
+    func image(forKey key: String) -> NSImage? {
+        cache.object(forKey: key as NSString)
+    }
+
+    func insertImage(_ image: NSImage, forKey key: String) {
+        cache.setObject(image, forKey: key as NSString, cost: image.representationSize)
+    }
+}
+
+private extension NSImage {
+    /// Rough estimate of the memory footprint of the bitmap representation of the image.
+    var representationSize: Int {
+        guard let tiffRepresentation = tiffRepresentation else { return 0 }
+        return tiffRepresentation.count
+    }
+} 

--- a/Utilities/ThumbnailGenerator.swift
+++ b/Utilities/ThumbnailGenerator.swift
@@ -1,0 +1,53 @@
+import Foundation
+import AppKit
+import ImageIO
+
+/// A helper that uses CGImageSource to create downsampled thumbnails efficiently.
+/// This avoids loading the full-size image into memory before resizing.
+struct ThumbnailGenerator {
+    /// Generate an `NSImage` thumbnail from raw image data.
+    /// - Parameters:
+    ///   - data: Encoded image data (PNG, JPEG, etc.).
+    ///   - maxPixelSize: The maximum width/height in pixels for the thumbnail.
+    /// - Returns: Downsampled `NSImage` or `nil`.
+    static func makeThumbnail(from data: Data, maxPixelSize: Int) -> NSImage? {
+        // Create image source without caching the full image into memory.
+        guard let source = CGImageSourceCreateWithData(data as CFData, [kCGImageSourceShouldCache: false] as CFDictionary) else {
+            return nil
+        }
+
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true
+        ]
+
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return nil
+        }
+
+        // Match the pixel dimensions – size given in points, so divide by scale.
+        let scale = NSScreen.main?.backingScaleFactor ?? 2
+        let size = NSSize(width: CGFloat(cgImage.width) / scale, height: CGFloat(cgImage.height) / scale)
+
+        return NSImage(cgImage: cgImage, size: size)
+    }
+
+    // MARK: - Internal concurrency limiter
+    // Creating thumbnails can be CPU-intensive; we gate the number of simultaneous
+    // decodes so scrolling won't spawn hundreds of threads.
+    private static let semaphore: DispatchSemaphore = {
+        // Allow more parallel decodes but keep an upper bound to avoid CPU starvation.
+        let coreCount = ProcessInfo.processInfo.activeProcessorCount
+        let limit = min(max(coreCount * 2, 8), 16) // 2× cores, at least 8, capped at 16
+        return DispatchSemaphore(value: limit)
+    }()
+
+    /// Same as `makeThumbnail`, but limits the number of concurrent thumbnail generations.
+    static func makeThumbnailLimited(from data: Data, maxPixelSize: Int) -> NSImage? {
+        semaphore.wait()
+        defer { semaphore.signal() }
+        return makeThumbnail(from: data, maxPixelSize: maxPixelSize)
+    }
+} 

--- a/Utilities/ThumbnailPreheater.swift
+++ b/Utilities/ThumbnailPreheater.swift
@@ -1,0 +1,53 @@
+import Foundation
+import AppKit
+
+/// Preheats (generates + caches) artwork thumbnails for a collection of library entities.
+/// This runs off the main thread so that UI interactions remain smooth.
+final class ThumbnailPreheater {
+    static let shared = ThumbnailPreheater()
+
+    // MARK: - Internal state
+    private var preheatTask: Task<Void, Never>?
+    private let listThumbnailSize = 96 * 2  // Same maxPixelSize used in EntityListView
+    private let gridItemWidth: CGFloat = 180 // Matches `itemWidth` in EntityGridView
+
+    private init() {}
+
+    /// Begins asynchronously generating thumbnails for the provided entities (albums/artists…) and
+    /// stores them in the shared `ImageCache` so that views can reuse them instantly.
+    /// If a previous pre-heat is still running it will be cancelled.
+    /// - Parameter entities: The entities whose artwork should be pre-cached.
+    func preheat<T: Entity>(entities: [T]) {
+        // Cancel any in-flight work so we don’t waste resources if the library refreshed.
+        preheatTask?.cancel()
+
+        preheatTask = Task.detached(priority: .utility) { [listThumbnailSize, gridItemWidth] in
+            for entity in entities {
+                // Respect cancellation – user may refresh library, quit the app, etc.
+                guard !Task.isCancelled else { return }
+
+                guard let artworkData = entity.artworkData, !artworkData.isEmpty else {
+                    continue
+                }
+
+                // List thumbnail (48×48 points, rendered at 2× scale)
+                let listKey = "\(entity.id.uuidString)-list"
+                if ImageCache.shared.image(forKey: listKey) == nil {
+                    if let image = ThumbnailGenerator.makeThumbnailLimited(from: artworkData,
+                                                                          maxPixelSize: listThumbnailSize) {
+                        ImageCache.shared.insertImage(image, forKey: listKey)
+                    }
+                }
+
+                // Grid thumbnail (180×180 points, rendered at 2× scale)
+                let gridKey = "\(entity.id.uuidString)-grid-\(Int(gridItemWidth))"
+                if ImageCache.shared.image(forKey: gridKey) == nil {
+                    if let image = ThumbnailGenerator.makeThumbnailLimited(from: artworkData,
+                                                                          maxPixelSize: Int(gridItemWidth * 2)) {
+                        ImageCache.shared.insertImage(image, forKey: gridKey)
+                    }
+                }
+            }
+        }
+    }
+} 


### PR DESCRIPTION
Well, it's not a pull request as such, I guess. There were just some things, that I (with o3's help) decided to change before starting to fully use the app. 

- Commit `376f20e` adds to the albums tab option to sort by the artist first, and then by the album name - to mimic the sorting from Music.app albums tab. 
- Commit `403b76b` optimizes the artwork loading, but by eating up a lot of memory, unfortunately (~750mb in my testing). I have 32gb of ram on my machine, and I would prefer the smooth scrolling to the thin memory footprint. YMMV.
- Commit `ca21fa9` disables the window adjusting behavior, because it was interfering with the [Aerospace](https://github.com/nikitabobko/AeroSpace) tiling manger. I'm not sure what exactly 'corrupted frames' are referring to, but when I switch spaces with the aerospace, the app would switch to the new space, aerospace would put it back to it's original space, the app tries to switch again and so on for a good 10 seconds, before the app just gives up switching.

Sorry for the hot vibe slop. It's all probably could've been written better, but the app is actually really impressive, so instead of creating a bunch of issues, I just decided to add some quick fixes to make it more usable for me. Maybe it can help you with the future development. Thanks!