### PR TITLE
Group tracks by disk and track number

### DIFF
--- a/Utilities/Constants.swift
+++ b/Utilities/Constants.swift
@@ -62,7 +62,6 @@ enum Icons {
     static let clockFill = "clock.fill"
     
     // Sort Icons
-    static let sortBy = "arrow.up.arrow.down"
     static let sortAscending = "sort.ascending"
     static let sortDescending = "sort.descending"
     

--- a/Utilities/Constants.swift
+++ b/Utilities/Constants.swift
@@ -62,6 +62,7 @@ enum Icons {
     static let clockFill = "clock.fill"
     
     // Sort Icons
+    static let sortBy = "arrow.up.arrow.down"
     static let sortAscending = "sort.ascending"
     static let sortDescending = "sort.descending"
     

--- a/Views/Components/TrackView.swift
+++ b/Views/Components/TrackView.swift
@@ -8,6 +8,7 @@ struct TrackView: View {
     let playlistID: UUID?
     let onPlayTrack: (Track) -> Void
     let contextMenuItems: (Track) -> [ContextMenuItem]
+    let showDiscHeaders: Bool
 
     @EnvironmentObject var playbackManager: PlaybackManager
 
@@ -17,7 +18,8 @@ struct TrackView: View {
             TrackListView(
                 tracks: tracks,
                 onPlayTrack: onPlayTrack,
-                contextMenuItems: contextMenuItems
+                contextMenuItems: contextMenuItems,
+                showDiscHeaders: showDiscHeaders
             )
         case .grid:
             TrackGridView(
@@ -96,7 +98,8 @@ struct TrackContextMenuContent: View {
         onPlayTrack: { track in
             Logger.debugPrint("Playing \(track.title)")
         },
-        contextMenuItems: { _ in [] }
+        contextMenuItems: { _ in [] },
+        showDiscHeaders: false
     )
     .frame(height: 400)
     .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
@@ -121,7 +124,8 @@ struct TrackContextMenuContent: View {
         onPlayTrack: { track in
             Logger.debugPrint("Playing \(track.title)")
         },
-        contextMenuItems: { _ in [] }
+        contextMenuItems: { _ in [] },
+        showDiscHeaders: false
     )
     .frame(height: 600)
     .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
@@ -148,7 +152,8 @@ struct TrackContextMenuContent: View {
         onPlayTrack: { track in
             Logger.debugPrint("Playing \(track.title)")
         },
-        contextMenuItems: { _ in [] }
+        contextMenuItems: { _ in [] },
+        showDiscHeaders: false
     )
     .frame(height: 600)
     .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
@@ -175,7 +180,8 @@ struct TrackContextMenuContent: View {
         onPlayTrack: { track in
             Logger.debugPrint("Playing \(track.title)")
         },
-        contextMenuItems: { _ in [] }
+        contextMenuItems: { _ in [] },
+        showDiscHeaders: false
     )
     .frame(height: 600)
     .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))

--- a/Views/Components/TrackView.swift
+++ b/Views/Components/TrackView.swift
@@ -8,7 +8,7 @@ struct TrackView: View {
     let playlistID: UUID?
     let onPlayTrack: (Track) -> Void
     let contextMenuItems: (Track) -> [ContextMenuItem]
-    let showDiscHeaders: Bool
+    let sortByDiscAndTrackNumber: Bool
 
     @EnvironmentObject var playbackManager: PlaybackManager
 
@@ -19,7 +19,7 @@ struct TrackView: View {
                 tracks: tracks,
                 onPlayTrack: onPlayTrack,
                 contextMenuItems: contextMenuItems,
-                showDiscHeaders: showDiscHeaders
+                sortByDiscAndTrackNumber: sortByDiscAndTrackNumber
             )
         case .grid:
             TrackGridView(
@@ -99,7 +99,7 @@ struct TrackContextMenuContent: View {
             Logger.debugPrint("Playing \(track.title)")
         },
         contextMenuItems: { _ in [] },
-        showDiscHeaders: false
+        sortByDiscAndTrackNumber: false
     )
     .frame(height: 400)
     .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
@@ -125,7 +125,7 @@ struct TrackContextMenuContent: View {
             Logger.debugPrint("Playing \(track.title)")
         },
         contextMenuItems: { _ in [] },
-        showDiscHeaders: false
+        sortByDiscAndTrackNumber: false
     )
     .frame(height: 600)
     .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
@@ -153,7 +153,7 @@ struct TrackContextMenuContent: View {
             Logger.debugPrint("Playing \(track.title)")
         },
         contextMenuItems: { _ in [] },
-        showDiscHeaders: false
+        sortByDiscAndTrackNumber: false
     )
     .frame(height: 600)
     .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))
@@ -181,7 +181,7 @@ struct TrackContextMenuContent: View {
             Logger.debugPrint("Playing \(track.title)")
         },
         contextMenuItems: { _ in [] },
-        showDiscHeaders: false
+        sortByDiscAndTrackNumber: false
     )
     .frame(height: 600)
     .environmentObject(PlaybackManager(libraryManager: LibraryManager(), playlistManager: PlaylistManager()))

--- a/Views/Components/TrackViews/TrackListView.swift
+++ b/Views/Components/TrackViews/TrackListView.swift
@@ -4,31 +4,51 @@ struct TrackListView: View {
     let tracks: [Track]
     let onPlayTrack: (Track) -> Void
     let contextMenuItems: (Track) -> [ContextMenuItem]
+    let showDiscHeaders: Bool
 
     @EnvironmentObject var playbackManager: PlaybackManager
     @State private var hoveredTrackID: UUID?
 
     var body: some View {
-        ScrollView {
+        // Pre-compute grouping to simplify view builder content
+        let grouped = Dictionary(grouping: tracks) { $0.discNumber ?? 1 }
+        let discKeys = grouped.keys.sorted()
+
+        return ScrollView {
             LazyVStack(spacing: 0, pinnedViews: []) {
-                ForEach(Array(tracks.enumerated()), id: \.element.id) { _, track in
-                    TrackListRow(
-                        track: track,
-                        isHovered: hoveredTrackID == track.id,
-                        onPlay: {
-                            let isCurrentTrack = playbackManager.currentTrack?.url.path == track.url.path
-                            if !isCurrentTrack {
-                                onPlayTrack(track)
-                            }
-                        },
-                        onHover: { isHovered in
-                            hoveredTrackID = isHovered ? track.id : nil
+                ForEach(discKeys, id: \.self) { disc in
+                    // Show header only if showDiscHeaders is true and (multi-disc album or disc number greater than 1)
+                    if showDiscHeaders && (discKeys.count > 1 || disc > 1) {
+                        HStack {
+                            Text("Disc \(disc)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.vertical, 4)
+                            Spacer()
                         }
-                    )
-                    .contextMenu {
-                        TrackContextMenuContent(items: contextMenuItems(track))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color(NSColor.textBackgroundColor))
                     }
-                    .id(track.id)
+
+                    ForEach(Array((grouped[disc] ?? []).enumerated()), id: \.element.id) { _, track in
+                        TrackListRow(
+                            track: track,
+                            isHovered: hoveredTrackID == track.id,
+                            onPlay: {
+                            let isCurrentTrack = playbackManager.currentTrack?.url.path == track.url.path
+                                if !isCurrentTrack {
+                                    onPlayTrack(track)
+                                }
+                            },
+                            onHover: { isHovered in
+                                hoveredTrackID = isHovered ? track.id : nil
+                            }
+                        )
+                        .contextMenu {
+                            TrackContextMenuContent(items: contextMenuItems(track))
+                        }
+                        .id(track.id)
+                    }
                 }
             }
             .padding(5)

--- a/Views/Components/TrackViews/TrackListView.swift
+++ b/Views/Components/TrackViews/TrackListView.swift
@@ -85,6 +85,12 @@ private struct TrackListRow: View {
                 PlayingIndicator()
                     .frame(width: 16)
                     .transition(.scale.combined(with: .opacity))
+            } else {
+                // Show track number when not showing play button or playing indicator
+                Text(trackNumberText)
+                    .font(.system(size: 12))
+                    .foregroundColor(.secondary)
+                    .transition(.scale.combined(with: .opacity))
             }
         }
         .frame(width: 40, height: 40)
@@ -270,5 +276,12 @@ private struct TrackListRow: View {
         let minutes = totalSeconds / 60
         let remainingSeconds = totalSeconds % 60
         return String(format: StringFormat.mmss, minutes, remainingSeconds)
+    }
+
+    private var trackNumberText: String {
+        if let num = track.trackNumber {
+            return String(num)
+        }
+        return ""
     }
 }

--- a/Views/Components/TrackViews/TrackTableView.swift
+++ b/Views/Components/TrackViews/TrackTableView.swift
@@ -224,12 +224,14 @@ struct TrackTableView: NSViewRepresentable {
             tableView.removeTableColumn(tableView.tableColumns[0])
         }
 
-        // Add play/pause column first
         let playColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("playPause"))
-        playColumn.title = "" // Empty header
+        playColumn.title = "#" // Track number column header
+        playColumn.headerCell.alignment = .center
+        // Enable sorting by track number when this column is clicked
+        playColumn.sortDescriptorPrototype = NSSortDescriptor(key: "trackNumber", ascending: true)
         playColumn.width = 32
         playColumn.minWidth = 32
-        playColumn.maxWidth = 32
+        playColumn.maxWidth = 40
         playColumn.resizingMask = [] // Fixed width, no resizing
         tableView.addTableColumn(playColumn)
 
@@ -1167,9 +1169,23 @@ struct PlayPauseCell: View {
                 // Show playing indicator only when actually playing
                 PlayingIndicator()
                     .frame(width: 16)
+            } else {
+                // Show track number when not hovered and not playing
+                Text(trackNumberText)
+                    .font(.system(size: 12))
+                    .foregroundColor(.secondary)
             }
         }
         .frame(width: 32, height: 44)
         .contentShape(Rectangle())
+    }
+
+    // MARK: - Helpers
+
+    private var trackNumberText: String {
+        if let num = track.trackNumber {
+            return String(num)
+        }
+        return ""
     }
 }

--- a/Views/Folders/FoldersView.swift
+++ b/Views/Folders/FoldersView.swift
@@ -178,7 +178,8 @@ struct FoldersView: View {
                 } else {
                     return []
                 }
-            }
+            },
+            showDiscHeaders: false
         )
     }
 

--- a/Views/Folders/FoldersView.swift
+++ b/Views/Folders/FoldersView.swift
@@ -179,7 +179,7 @@ struct FoldersView: View {
                     return []
                 }
             },
-            showDiscHeaders: false
+            sortByDiscAndTrackNumber: false
         )
     }
 

--- a/Views/Home/EntityDetailView.swift
+++ b/Views/Home/EntityDetailView.swift
@@ -48,7 +48,8 @@ struct EntityDetailView: View {
                             playlistManager: playlistManager,
                             currentContext: .library
                         )
-                    }
+                    },
+                    showDiscHeaders: trackListSortByNumber
                 )
                 .background(Color(NSColor.textBackgroundColor))
             }
@@ -159,9 +160,9 @@ struct EntityDetailView: View {
             }
         } else {
             return trackListSortAscending
-            ? tracks.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
-            : tracks.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedDescending }
-    }
+                ? tracks.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+                : tracks.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedDescending }
+        }
     }
     
     private var entityArtwork: some View {

--- a/Views/Home/EntityDetailView.swift
+++ b/Views/Home/EntityDetailView.swift
@@ -49,7 +49,7 @@ struct EntityDetailView: View {
                             currentContext: .library
                         )
                     },
-                    showDiscHeaders: trackListSortByNumber
+                    sortByDiscAndTrackNumber: trackListSortByNumber
                 )
                 .background(Color(NSColor.textBackgroundColor))
             }

--- a/Views/Home/EntityDetailView.swift
+++ b/Views/Home/EntityDetailView.swift
@@ -107,35 +107,43 @@ struct EntityDetailView: View {
                 // Sort menu for list/grid views
                 if viewType != .table {
                     Menu {
-                        Text("Sort by:")
+                        Toggle("Title", isOn: Binding(
+                            get: { !trackListSortByNumber },
+                            set: { _ in
+                                trackListSortByNumber = false
+                            }
+                        ))
                         
-                        Button("Title ↑") {
-                            trackListSortByNumber = false
-                            trackListSortAscending = true
-                        }
-                        
-                        Button("Title ↓") {
-                            trackListSortByNumber = false
-                            trackListSortAscending = false
-                        }
+                        Toggle("Track number", isOn: Binding(
+                            get: { trackListSortByNumber },
+                            set: { _ in
+                                trackListSortByNumber = true
+                            }
+                        ))
                         
                         Divider()
                         
-                        Button("Track number ↑") {
-                            trackListSortByNumber = true
-                            trackListSortAscending = true
-                        }
+                        Toggle("Ascending", isOn: Binding(
+                            get: { trackListSortAscending },
+                            set: { _ in
+                                trackListSortAscending = true
+                            }
+                        ))
                         
-                        Button("Track number ↓") {
-                            trackListSortByNumber = true
-                            trackListSortAscending = false
-                        }
+                        Toggle("Descending", isOn: Binding(
+                            get: { !trackListSortAscending },
+                            set: { _ in
+                                trackListSortAscending = false
+                            }
+                        ))
                     } label: {
-                        Image(systemName: Icons.sortBy)
+                        Image(systemName: "line.3.horizontal.decrease")
                             .font(.system(size: 14))
                             .foregroundColor(.secondary)
                     }
-                    .buttonStyle(.borderless)
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .fixedSize()
                     .help("Sort tracks")
                 }
             }

--- a/Views/Home/HomeView.swift
+++ b/Views/Home/HomeView.swift
@@ -187,7 +187,8 @@ struct HomeView: View {
                             playlistManager: playlistManager,
                             currentContext: .library
                         )
-                    }
+                    },
+                    showDiscHeaders: false
                 )
                 .background(Color(NSColor.textBackgroundColor))
             }
@@ -409,7 +410,8 @@ struct HomeView: View {
                                     playlistManager: playlistManager,
                                     currentContext: .library
                                 )
-                            }
+                            },
+                            showDiscHeaders: false
                         )
                         .background(Color(NSColor.textBackgroundColor))
                     }

--- a/Views/Home/HomeView.swift
+++ b/Views/Home/HomeView.swift
@@ -188,7 +188,7 @@ struct HomeView: View {
                             currentContext: .library
                         )
                     },
-                    showDiscHeaders: false
+                    sortByDiscAndTrackNumber: false
                 )
                 .background(Color(NSColor.textBackgroundColor))
             }
@@ -411,7 +411,7 @@ struct HomeView: View {
                                     currentContext: .library
                                 )
                             },
-                            showDiscHeaders: false
+                            sortByDiscAndTrackNumber: false
                         )
                         .background(Color(NSColor.textBackgroundColor))
                     }

--- a/Views/Library/LibraryView.swift
+++ b/Views/Library/LibraryView.swift
@@ -145,7 +145,7 @@ struct LibraryView: View {
                             currentContext: .library
                         )
                     },
-                    showDiscHeaders: false
+                    sortByDiscAndTrackNumber: false
                 )
                 .background(Color(NSColor.textBackgroundColor))
             }

--- a/Views/Library/LibraryView.swift
+++ b/Views/Library/LibraryView.swift
@@ -144,7 +144,8 @@ struct LibraryView: View {
                             playlistManager: playlistManager,
                             currentContext: .library
                         )
-                    }
+                    },
+                    showDiscHeaders: false
                 )
                 .background(Color(NSColor.textBackgroundColor))
             }

--- a/Views/Playlists/PlaylistDetailView.swift
+++ b/Views/Playlists/PlaylistDetailView.swift
@@ -232,7 +232,8 @@ struct PlaylistDetailView: View {
                         } else {
                             return []
                         }
-                    }
+                    },
+                    showDiscHeaders: false
                 )
                 .background(Color(NSColor.textBackgroundColor))
             }

--- a/Views/Playlists/PlaylistDetailView.swift
+++ b/Views/Playlists/PlaylistDetailView.swift
@@ -233,7 +233,7 @@ struct PlaylistDetailView: View {
                             return []
                         }
                     },
-                    showDiscHeaders: false
+                    sortByDiscAndTrackNumber: false
                 )
                 .background(Color(NSColor.textBackgroundColor))
             }


### PR DESCRIPTION
Implemented showing the track number below the play/playing indicator for list and table track lists. 
Added the option to select sorting tracks by the track number instead of the track name. If the option is selected, and in the track list there are multiple albums, it will sort by the album first and show the album name as the header. Same goes if there are multiple disks in the album, it will sort them by the disk number, and show it in the header. If the default option of sorting by track name is selected, there will be no behavior changes.