### PR TITLE
Optimized loading the artwork in albums and tracks list

### DIFF
--- a/Managers/Library/LMLibrary.swift
+++ b/Managers/Library/LMLibrary.swift
@@ -112,6 +112,10 @@ extension LibraryManager {
         }
 
         refreshEntities()
+
+        // Kick off asynchronous thumbnail preheating so that album/artist artwork is already cached
+        ThumbnailPreheater.shared.preheat(entities: cachedAlbumEntities)
+
         // Post notification that library is loaded
         NotificationCenter.default.post(name: NSNotification.Name("LibraryDidLoad"), object: nil)
     }

--- a/Utilities/ImageCache.swift
+++ b/Utilities/ImageCache.swift
@@ -1,0 +1,34 @@
+import Foundation
+import AppKit
+
+/// A shared in-memory image cache for storing already-resized artwork images.
+/// The cache uses `NSCache` so the system can automatically purge it under memory pressure.
+final class ImageCache {
+    static let shared = ImageCache()
+
+    private let cache: NSCache<NSString, NSImage>
+
+    private init() {
+        let cache = NSCache<NSString, NSImage>()
+        // Limit the number of thumbnails and total memory cost (in bytes) to avoid unbounded growth.
+        cache.countLimit = 10_000
+        cache.totalCostLimit = 600 * 1_024 * 1_024 // ~600 MB
+        self.cache = cache
+    }
+
+    func image(forKey key: String) -> NSImage? {
+        cache.object(forKey: key as NSString)
+    }
+
+    func insertImage(_ image: NSImage, forKey key: String) {
+        cache.setObject(image, forKey: key as NSString, cost: image.representationSize)
+    }
+}
+
+private extension NSImage {
+    /// Rough estimate of the memory footprint of the bitmap representation of the image.
+    var representationSize: Int {
+        guard let tiffRepresentation = tiffRepresentation else { return 0 }
+        return tiffRepresentation.count
+    }
+} 

--- a/Utilities/ThumbnailGenerator.swift
+++ b/Utilities/ThumbnailGenerator.swift
@@ -1,0 +1,53 @@
+import Foundation
+import AppKit
+import ImageIO
+
+/// A helper that uses CGImageSource to create downsampled thumbnails efficiently.
+/// This avoids loading the full-size image into memory before resizing.
+struct ThumbnailGenerator {
+    /// Generate an `NSImage` thumbnail from raw image data.
+    /// - Parameters:
+    ///   - data: Encoded image data (PNG, JPEG, etc.).
+    ///   - maxPixelSize: The maximum width/height in pixels for the thumbnail.
+    /// - Returns: Downsampled `NSImage` or `nil`.
+    static func makeThumbnail(from data: Data, maxPixelSize: Int) -> NSImage? {
+        // Create image source without caching the full image into memory.
+        guard let source = CGImageSourceCreateWithData(data as CFData, [kCGImageSourceShouldCache: false] as CFDictionary) else {
+            return nil
+        }
+
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true
+        ]
+
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return nil
+        }
+
+        // Match the pixel dimensions – size given in points, so divide by scale.
+        let scale = NSScreen.main?.backingScaleFactor ?? 2
+        let size = NSSize(width: CGFloat(cgImage.width) / scale, height: CGFloat(cgImage.height) / scale)
+
+        return NSImage(cgImage: cgImage, size: size)
+    }
+
+    // MARK: - Internal concurrency limiter
+    // Creating thumbnails can be CPU-intensive; we gate the number of simultaneous
+    // decodes so scrolling won't spawn hundreds of threads.
+    private static let semaphore: DispatchSemaphore = {
+        // Allow more parallel decodes but keep an upper bound to avoid CPU starvation.
+        let coreCount = ProcessInfo.processInfo.activeProcessorCount
+        let limit = min(max(coreCount * 2, 8), 16) // 2× cores, at least 8, capped at 16
+        return DispatchSemaphore(value: limit)
+    }()
+
+    /// Same as `makeThumbnail`, but limits the number of concurrent thumbnail generations.
+    static func makeThumbnailLimited(from data: Data, maxPixelSize: Int) -> NSImage? {
+        semaphore.wait()
+        defer { semaphore.signal() }
+        return makeThumbnail(from: data, maxPixelSize: maxPixelSize)
+    }
+} 

--- a/Utilities/ThumbnailPreheater.swift
+++ b/Utilities/ThumbnailPreheater.swift
@@ -1,0 +1,87 @@
+import Foundation
+import AppKit
+
+/// Preheats (generates + caches) artwork thumbnails for a collection of library entities.
+/// This runs off the main thread so that UI interactions remain smooth.
+final class ThumbnailPreheater {
+    static let shared = ThumbnailPreheater()
+
+    // MARK: - Internal state
+    private var preheatTask: Task<Void, Never>?
+    private let listThumbnailSize = 96 * 2  // Same maxPixelSize used in EntityListView
+    private let gridItemWidth: CGFloat = 180 // Matches `itemWidth` in EntityGridView
+
+    // Track list thumbnail properties
+    private let trackThumbnailSize = 40 * 4 // 40pt thumbnail rendered at 2× (plus wiggle room for higher density)
+
+    // Separate task for track thumbnail preheating so album/artist and track preheats don't cancel each other out
+    private var trackPreheatTask: Task<Void, Never>?
+
+    private init() {}
+
+    /// Begins asynchronously generating thumbnails for the provided entities (albums/artists…) and
+    /// stores them in the shared `ImageCache` so that views can reuse them instantly.
+    /// If a previous pre-heat is still running it will be cancelled.
+    /// - Parameter entities: The entities whose artwork should be pre-cached.
+    func preheat<T: Entity>(entities: [T]) {
+        // Cancel any in-flight work so we don’t waste resources if the library refreshed.
+        preheatTask?.cancel()
+
+        preheatTask = Task.detached(priority: .utility) { [listThumbnailSize, gridItemWidth] in
+            for entity in entities {
+                // Respect cancellation – user may refresh library, quit the app, etc.
+                guard !Task.isCancelled else { return }
+
+                guard let artworkData = entity.artworkData, !artworkData.isEmpty else {
+                    continue
+                }
+
+                // List thumbnail (48×48 points, rendered at 2× scale)
+                let listKey = "\(entity.id.uuidString)-list"
+                if ImageCache.shared.image(forKey: listKey) == nil {
+                    if let image = ThumbnailGenerator.makeThumbnailLimited(from: artworkData,
+                                                                          maxPixelSize: listThumbnailSize) {
+                        ImageCache.shared.insertImage(image, forKey: listKey)
+                    }
+                }
+
+                // Grid thumbnail (180×180 points, rendered at 2× scale)
+                let gridKey = "\(entity.id.uuidString)-grid-\(Int(gridItemWidth))"
+                if ImageCache.shared.image(forKey: gridKey) == nil {
+                    if let image = ThumbnailGenerator.makeThumbnailLimited(from: artworkData,
+                                                                          maxPixelSize: Int(gridItemWidth * 2)) {
+                        ImageCache.shared.insertImage(image, forKey: gridKey)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Begins asynchronously generating thumbnails for the provided tracks and stores them in `ImageCache`.
+    /// Cancels any previous track preheat work to prioritize the newest list being shown.
+    /// - Parameter tracks: The tracks whose artwork should be pre-cached.
+    func preheat(tracks: [Track]) {
+        // Cancel any in-flight track work so we don’t waste resources if the list changes.
+        trackPreheatTask?.cancel()
+
+        trackPreheatTask = Task.detached(priority: .utility) { [trackThumbnailSize] in
+            for track in tracks {
+                // Respect cancellation
+                guard !Task.isCancelled else { return }
+
+                guard let artworkData = track.artworkData, !artworkData.isEmpty else {
+                    continue
+                }
+
+                // Track list thumbnail (40×40 points, rendered at 2× scale)
+                let listKey = "\(track.id.uuidString)-track-list"
+                if ImageCache.shared.image(forKey: listKey) == nil {
+                    if let image = ThumbnailGenerator.makeThumbnailLimited(from: artworkData,
+                                                                          maxPixelSize: trackThumbnailSize) {
+                        ImageCache.shared.insertImage(image, forKey: listKey)
+                    }
+                }
+            }
+        }
+    }
+} 

--- a/Views/Components/TrackViews/TrackListView.swift
+++ b/Views/Components/TrackViews/TrackListView.swift
@@ -32,6 +32,9 @@ struct TrackListView: View {
                 }
             }
             .padding(5)
+            .onAppear {
+                ThumbnailPreheater.shared.preheat(tracks: tracks)
+            }
         }
     }
 }
@@ -45,6 +48,7 @@ private struct TrackListRow: View {
 
     @EnvironmentObject var playbackManager: PlaybackManager
     @State private var artworkImage: NSImage?
+    @State private var artworkLoadTask: Task<Void, Never>? // Task to manage async artwork loading and allow cancellation
 
     var body: some View {
         HStack(spacing: 0) {
@@ -117,8 +121,16 @@ private struct TrackListRow: View {
                 loadingArtwork
             }
         }
-        .task { await loadArtwork() }
-        .onDisappear { artworkImage = nil }
+        // Perform artwork loading with Task for better cancellation and concurrency control
+        .onAppear {
+            loadArtworkAsync()
+        }
+        .onDisappear {
+            // Cancel loading task and clear image to free memory
+            artworkLoadTask?.cancel()
+            artworkLoadTask = nil
+            artworkImage = nil
+        }
     }
 
     private var placeholderArtwork: some View {
@@ -249,18 +261,35 @@ private struct TrackListRow: View {
         }
     }
 
-    private func loadArtwork() async {
-        guard artworkImage == nil else { return }
+    /// Optimized artwork loading with caching and limited concurrency thumbnail generation (similar to EntityListView)
+    private func loadArtworkAsync() {
+        // Prevent duplicate tasks
+        guard artworkLoadTask == nil else { return }
 
-        await withCheckedContinuation { continuation in
-            Task {
-                if let artworkData = track.artworkData,
-                   let image = NSImage(data: artworkData) {
+        // Try cache first
+        let cacheKey = "\(track.id.uuidString)-track-list"
+        if let cachedImage = ImageCache.shared.image(forKey: cacheKey) {
+            self.artworkImage = cachedImage
+            return
+        }
+
+        artworkLoadTask = Task {
+            // Yield once to allow SwiftUI finish layout before heavy work
+            await Task.yield()
+
+            guard !Task.isCancelled else { return }
+
+            if let data = track.artworkData {
+                // Generate downsampled thumbnail with concurrency limit
+                if let thumbnailImage = ThumbnailGenerator.makeThumbnailLimited(from: data, maxPixelSize: 160) { // 40pt * 4 for high-res displays
+                    // Insert into cache
+                    ImageCache.shared.insertImage(thumbnailImage, forKey: cacheKey)
+
                     await MainActor.run {
-                        self.artworkImage = image
+                        guard !Task.isCancelled else { return }
+                        self.artworkImage = thumbnailImage
                     }
                 }
-                continuation.resume()
             }
         }
     }


### PR DESCRIPTION
Now, this one is definitely not a full blown PR. 
The optimizations mostly revolve around artwork caching. When the albums or tracks list appears, it starts generating the resized artworks for them in the background, then stores them in the NSCache. When the artwork should be displayed, it checks the cache for the resized artwork first. This seems to result in a much smoother scrolling, but comes at expense of extensive RAM usage, sometimes exceeding 1GB and coming close to 2GB. As there are Macs with 8GB of RAM still circulating around, I don't think this changes should be merged as is.

<img width="188" height="32" alt="Screenshot 2025-07-11 at 22 22 28" src="https://github.com/user-attachments/assets/55b25f0d-aced-4e23-94ee-41773cb7ed55" />

I'll mark this PR as draft, just as a suggestion for further investigation I guess, as currently scrolling causes lags on a large libraries, unfortunately.