### PR TITLE
Add support for hard refreshing library

### DIFF
--- a/Managers/Database/DMFolders.swift
+++ b/Managers/Database/DMFolders.swift
@@ -160,7 +160,7 @@ extension DatabaseManager {
         }
     }
 
-    func refreshFolder(_ folder: Folder, completion: @escaping (Result<Void, Error>) -> Void) {
+    func refreshFolder(_ folder: Folder, hardRefresh: Bool = false, _ completion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             do {
                 await MainActor.run {
@@ -174,7 +174,7 @@ extension DatabaseManager {
                 Logger.info("Starting refresh for folder \(folder.name) with \(trackCountBefore) tracks")
 
                 // Scan the folder - this will check for metadata updates
-                try await scanSingleFolder(folder, supportedExtensions: AudioFormat.supportedExtensions)
+                try await scanSingleFolder(folder, supportedExtensions: AudioFormat.supportedExtensions, hardRefresh: hardRefresh)
 
                 // Update folder's metadata
                 if let folderId = folder.id {
@@ -366,6 +366,7 @@ extension DatabaseManager {
     func scanSingleFolder(
         _ folder: Folder,
         supportedExtensions: [String],
+        hardRefresh: Bool = false,
         globalScanState: GlobalScanState? = nil
     ) async throws {
         guard let folderId = folder.id else {
@@ -409,6 +410,7 @@ extension DatabaseManager {
             folderId: folderId,
             artworkMap: artworkMap,
             folderName: folder.name,
+            hardRefresh: hardRefresh,
             scanState: scanState,
             globalScanState: globalScanState
         )
@@ -501,6 +503,7 @@ extension DatabaseManager {
         folderId: Int64,
         artworkMap: [URL: Data],
         folderName: String,
+        hardRefresh: Bool = false,
         scanState: ScanState,
         globalScanState: GlobalScanState? = nil
     ) async throws {
@@ -515,6 +518,7 @@ extension DatabaseManager {
                 try await processBatch(
                     batchWithFolderId,
                     artworkMap: artworkMap,
+                    hardRefresh: hardRefresh,
                     scanState: scanState,
                     folderName: folderName,
                     totalFilesInFolder: totalFiles,

--- a/Managers/Library/LMFolders.swift
+++ b/Managers/Library/LMFolders.swift
@@ -80,7 +80,7 @@ extension LibraryManager {
         }
     }
 
-    func refreshFolder(_ folder: Folder) {
+    func refreshFolder(_ folder: Folder, hardRefresh: Bool = false) {
         // First, ensure we have a valid bookmark
         Task {
             // Refresh bookmark if needed
@@ -93,7 +93,7 @@ extension LibraryManager {
                 guard let self = self else { return }
 
                 // Delegate to database manager for refresh
-                self.databaseManager.refreshFolder(folder) { result in
+                self.databaseManager.refreshFolder(folder, hardRefresh: hardRefresh) { result in
                     switch result {
                     case .success:
                         Logger.info("Successfully refreshed folder \(folder.name)")

--- a/Views/Folders/FoldersView.swift
+++ b/Views/Folders/FoldersView.swift
@@ -163,8 +163,8 @@ struct FoldersView: View {
 
     // MARK: - Helper Methods
 
-    private func refreshFolder(_ folder: Folder) {
-        libraryManager.refreshFolder(folder)
+    private func refreshFolder(_ folder: Folder, hardRefresh: Bool = false) {
+        libraryManager.refreshFolder(folder, hardRefresh: hardRefresh)
     }
 
     // MARK: - Hierarchical Sidebar Helper Methods


### PR DESCRIPTION
Adds support for hard refreshing full library to update complete metadata without having to re-add folders.

User can perform this action by going to Settings > Library, and hold down <kbd>⌘</kbd> key which will turn refresh buttons to show different icon and text, indicating that clicking it while <kbd>⌘</kbd> is being held will cause hard refresh.


https://github.com/user-attachments/assets/74b8d610-28ee-4ab2-9719-a1e99f5b3050

