### PR TITLE
Add favorites column to view & update track favorite state

### DIFF
--- a/Managers/Playlist/PMTrackUpdate.swift
+++ b/Managers/Playlist/PMTrackUpdate.swift
@@ -26,6 +26,14 @@ extension PlaylistManager {
                 
                 await handleTrackPropertyUpdate(updatedTrack)
                 
+                await MainActor.run {
+                    NotificationCenter.default.post(
+                        name: .trackFavoriteStatusChanged,
+                        object: nil,
+                        userInfo: ["track": updatedTrack]
+                    )
+                }
+                
                 if let favoritesIndex = playlists.firstIndex(where: {
                     $0.name == DefaultPlaylists.favorites && $0.type == .smart
                 }) {

--- a/Managers/Playlist/PlaylistManager.swift
+++ b/Managers/Playlist/PlaylistManager.swift
@@ -50,11 +50,29 @@ class PlaylistManager: ObservableObject {
 
     // MARK: - Convenience Methods
 
-    /// Toggle favorite status for a track
-    func toggleFavorite(for track: Track) {
-        // Simply toggle the favorite status - the system will handle the rest
+    /// Toggle favorite status for a single track
+    func toggleFavorite(for track: Track, currentState: Bool? = nil) {
+        let finalState: Bool?
+        if let currentState = currentState {
+            finalState = !currentState
+        } else {
+            finalState = nil
+        }
+        toggleFavorite(for: [track], setTo: finalState)
+    }
+
+    /// Toggle favorite status for multiple tracks
+    func toggleFavorite(for tracks: [Track], setTo finalState: Bool? = nil) {
         Task {
-            await updateTrackFavoriteStatus(track: track, isFavorite: !track.isFavorite)
+            for track in tracks {
+                let isFavorite: Bool
+                if let finalState = finalState {
+                    isFavorite = finalState
+                } else {
+                    isFavorite = !track.isFavorite
+                }
+                await updateTrackFavoriteStatus(track: track, isFavorite: isFavorite)
+            }
         }
     }
 

--- a/Utilities/Constants.swift
+++ b/Utilities/Constants.swift
@@ -243,6 +243,7 @@ extension Notification.Name {
     static let playPlaylistTracks = Notification.Name("playPlaylistTracks")
     static let trackTableSortChanged = Notification.Name("trackTableSortChanged")
     static let trackTableRowSizeChanged = Notification.Name("trackTableRowSizeChanged")
+    static let trackFavoriteStatusChanged = Notification.Name("trackFavoriteStatusChanged")
     
     static let focusSearchField = Notification.Name("FocusSearchField")
 }

--- a/Views/Components/TrackContextMenu.swift
+++ b/Views/Components/TrackContextMenu.swift
@@ -338,12 +338,10 @@ enum TrackContextMenu {
         
         items.append(.menu(title: "Add to Playlist", icon: "text.badge.plus", items: playlistItems))
         
-        items.append(.button(title: "Add to Favorites", icon: Icons.star) {
-            for track in tracks {
-                if !track.isFavorite {
-                    playlistManager.toggleFavorite(for: track)
-                }
-            }
+        let allFavorited = tracks.allSatisfy { $0.isFavorite }
+        let title = allFavorited ? "Remove from Favorites" : "Add to Favorites"
+        items.append(.button(title: title, icon: Icons.star) {
+            playlistManager.toggleFavorite(for: tracks, setTo: !allFavorited)
         })
         
         if case .playlist(let playlist) = currentContext, playlist.type == .regular {

--- a/Views/Components/TrackViews/TrackTableOptionsDropdown.swift
+++ b/Views/Components/TrackViews/TrackTableOptionsDropdown.swift
@@ -5,6 +5,7 @@ import SwiftUI
 enum TrackSortField: String, CaseIterable {
     case trackNumber = "trackNumber"
     case discNumber = "discNumber"
+    case favorite = "favorite"
     case title = "title"
     case artist = "artist"
     case album = "album"
@@ -19,6 +20,7 @@ enum TrackSortField: String, CaseIterable {
         switch self {
         case .trackNumber: return "Track number (#)"
         case .discNumber: return "Disc number"
+        case .favorite: return "Favorite"
         case .title: return "Title"
         case .artist: return "Artist"
         case .album: return "Album"
@@ -35,6 +37,7 @@ enum TrackSortField: String, CaseIterable {
         let sortComparators: [TrackSortField: KeyPathComparator<Track>] = [
             .trackNumber: KeyPathComparator(\Track.sortableTrackNumber, order: ascending ? .forward : .reverse),
             .discNumber: KeyPathComparator(\Track.sortableDiscNumber, order: ascending ? .forward : .reverse),
+            .favorite: KeyPathComparator(\Track.sortableIsFavorite, order: ascending ? .forward : .reverse),
             .title: KeyPathComparator(\Track.title, order: ascending ? .forward : .reverse),
             .artist: KeyPathComparator(\Track.artist, order: ascending ? .forward : .reverse),
             .album: KeyPathComparator(\Track.album, order: ascending ? .forward : .reverse),
@@ -50,7 +53,7 @@ enum TrackSortField: String, CaseIterable {
     }
     
     static var sortFields: [TrackSortField] {
-        [.trackNumber, .discNumber, .title, .artist, .album, .genre, .year, .composer, .filename, .duration, .dateAdded]
+        [.trackNumber, .discNumber, .favorite, .title, .artist, .album, .genre, .year, .composer, .filename, .duration, .dateAdded]
     }
 }
 
@@ -80,6 +83,7 @@ struct TrackTableOptionsDropdown: View {
             "dateAdded": TrackSortField.dateAdded,
             "sortableTrackNumber": TrackSortField.trackNumber,
             "sortableDiscNumber": TrackSortField.discNumber,
+            "sortableIsFavorite": TrackSortField.favorite,
             "title": TrackSortField.title,
             "artist": TrackSortField.artist,
             "album": TrackSortField.album,


### PR DESCRIPTION
Adds Favorite column on Tracks list to allow user to view and update track favorite state right from the tracks list.

Fixes #88