### PR TITLE
Show track lyrics when available

### DIFF
--- a/Core/LyricsLoader.swift
+++ b/Core/LyricsLoader.swift
@@ -1,0 +1,145 @@
+import Foundation
+import GRDB
+
+struct LyricsLoader {
+    /// Load lyrics for a track, checking external files first, then embedded lyrics
+    /// - Parameters:
+    ///   - track: The track to load lyrics for
+    ///   - dbQueue: Database queue for fetching embedded lyrics
+    /// - Returns: Tuple containing lyrics text and source type
+    static func loadLyrics(
+        for track: Track,
+        using dbQueue: DatabaseQueue
+    ) async throws -> (lyrics: String, source: LyricsSource) {
+        // First, check for external LRC/SRT files
+        if let externalLyrics = try? loadExternalLyrics(for: track) {
+            return externalLyrics
+        }
+        
+        // Fall back to embedded lyrics
+        if let fullTrack = try? await track.fullTrack(using: dbQueue),
+           let embeddedLyrics = fullTrack.extendedMetadata?.lyrics,
+           !embeddedLyrics.isEmpty {
+            return (embeddedLyrics, .embedded)
+        }
+        
+        // No lyrics found
+        return ("", .none)
+    }
+    
+    /// Check for and load external lyrics files (.lrc or .srt)
+    private static func loadExternalLyrics(for track: Track) throws -> (lyrics: String, source: LyricsSource)? {
+        let trackURL = track.url
+        let baseURL = trackURL.deletingPathExtension()
+        
+        // Define file extensions to check in priority order
+        let lyricsFormats: [(extension: String, source: LyricsSource, parser: (String) -> String)] = [
+            ("lrc", .lrc, parseLRC),
+            ("srt", .srt, parseSRT)
+        ]
+        
+        for format in lyricsFormats {
+            let lyricsURL = baseURL.appendingPathExtension(format.extension)
+            if FileManager.default.fileExists(atPath: lyricsURL.path),
+               let content = loadFileWithEncodingDetection(lyricsURL),
+               !content.isEmpty {
+                return (format.parser(content), format.source)
+            }
+        }
+        
+        return nil
+    }
+
+    /// Load file content with automatic encoding detection
+    private static func loadFileWithEncodingDetection(_ url: URL) -> String? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        
+        // Try UTF-8 first
+        if let content = String(data: data, encoding: .utf8) {
+            return content
+        }
+        
+        // Fall back to automatic detection for other encodings
+        let usedEncoding: UInt = 0
+        if let nsString = NSString(data: data, encoding: usedEncoding) {
+            return nsString as String
+        }
+        
+        return nil
+    }
+    
+    /// Parse LRC file format and extract lyrics text
+    private static func parseLRC(_ content: String) -> String {
+        let lines = content.components(separatedBy: .newlines)
+        var lyricsLines: [String] = []
+        
+        for line in lines {
+            // LRC format: [mm:ss.xx]lyrics text
+            // Remove timestamp and metadata tags for now
+            if line.hasPrefix("[") {
+                if let endBracket = line.firstIndex(of: "]") {
+                    let afterBracket = line.index(after: endBracket)
+                    if afterBracket < line.endIndex {
+                        let lyricsText = String(line[afterBracket...]).trimmingCharacters(in: .whitespaces)
+                        if !lyricsText.isEmpty {
+                            // Skip metadata lines (ar:, ti:, al:, etc.)
+                            let tag = String(line[line.index(after: line.startIndex)..<endBracket])
+                            if !tag.contains(":") || tag.contains(".") {
+                                lyricsLines.append(lyricsText)
+                            }
+                        }
+                    }
+                }
+            } else if !line.trimmingCharacters(in: .whitespaces).isEmpty {
+                lyricsLines.append(line)
+            }
+        }
+        
+        return lyricsLines.joined(separator: "\n")
+    }
+    
+    /// Parse SRT file format and extract lyrics text (ignoring timestamps for now)
+    private static func parseSRT(_ content: String) -> String {
+        let lines = content.components(separatedBy: .newlines)
+        var lyricsLines: [String] = []
+        var skipNext = false
+        
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            
+            // Skip empty lines and sequence numbers
+            if trimmed.isEmpty {
+                skipNext = false
+                continue
+            }
+            
+            // Skip timestamp lines (format: 00:00:00,000 --> 00:00:00,000)
+            if trimmed.contains("-->") {
+                skipNext = true
+                continue
+            }
+            
+            // Skip sequence numbers (just digits)
+            if trimmed.allSatisfy({ $0.isNumber }) {
+                continue
+            }
+            
+            // Skip the line immediately after timestamp
+            if skipNext {
+                skipNext = false
+            }
+            
+            // This is lyrics text
+            lyricsLines.append(trimmed)
+        }
+        
+        return lyricsLines.joined(separator: "\n")
+    }
+}
+
+enum LyricsSource {
+    case lrc
+    case srt
+    case embedded
+    case none
+}

--- a/Resources/Assets.xcassets/custom.music.microphone.bubble.right.symbolset/Contents.json
+++ b/Resources/Assets.xcassets/custom.music.microphone.bubble.right.symbolset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "filename" : "custom.music.microphone.bubble.right.svg",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/Resources/Assets.xcassets/custom.music.microphone.bubble.right.symbolset/custom.music.microphone.bubble.right.svg
+++ b/Resources/Assets.xcassets/custom.music.microphone.bubble.right.symbolset/custom.music.microphone.bubble.right.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Generator: Apple Native CoreSVG 341-->
+<!DOCTYPE svg
+PUBLIC "-//W3C//DTD SVG 1.1//EN"
+       "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 3300 2200">
+ <!--glyph: "", point size: 100.0, font version: "21.0d6e2", template writer version: "138.0.0"-->
+ <style>.defaults {-sfsymbols-variable-value-mode:color;-sfsymbols-draw-reverses-motion-groups:true}
+
+.monochrome-0 {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:-eb17209c8d6a40c _enclosure.stroke bubble.right}
+.monochrome-1 {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-eb17209c8d6a40c 5f7d59836251222d music.microphone}
+
+.multicolor-0:tintColor {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:-eb17209c8d6a40c _enclosure.stroke bubble.right}
+.multicolor-1:tintColor {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-eb17209c8d6a40c 5f7d59836251222d music.microphone}
+
+.hierarchical-0:secondary {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:-eb17209c8d6a40c _enclosure.stroke bubble.right}
+.hierarchical-1:primary {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-eb17209c8d6a40c 5f7d59836251222d music.microphone}
+
+.SFSymbolsPreviewWireframe {fill:none;opacity:1.0;stroke:black;stroke-width:0.5}
+</style>
+ <g id="Notes">
+  <rect height="2200" id="artboard" style="fill:white;opacity:1" width="3300" x="0" y="0"/>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="292" y2="292"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 322)">Weight/Scale Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 559.711 322)">Ultralight</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 856.422 322)">Thin</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1153.13 322)">Light</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1449.84 322)">Regular</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1746.56 322)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2043.27 322)">Semibold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2339.98 322)">Bold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2636.69 322)">Heavy</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2933.4 322)">Black</text>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1903" y2="1903"/>
+  <g transform="matrix(0.2 0 0 0.2 263 1933)">
+   <path d="m46.2402 4.15039c21.7773 0 39.4531-17.627 39.4531-39.4043s-17.6758-39.4043-39.4531-39.4043c-21.7285 0-39.4043 17.627-39.4043 39.4043s17.6758 39.4043 39.4043 39.4043Zm0-7.42188c-17.6758 0-31.9336-14.3066-31.9336-31.9824s14.2578-31.9824 31.9336-31.9824 31.9824 14.3066 31.9824 31.9824-14.3066 31.9824-31.9824 31.9824Zm3.61328-17.7734v-28.4668c0-2.24609-1.46484-3.75977-3.71094-3.75977-2.14844 0-3.61328 1.51367-3.61328 3.75977v28.4668c0 2.19727 1.46484 3.71094 3.61328 3.71094 2.24609 0 3.71094-1.51367 3.71094-3.71094Zm-17.8223-10.5957h28.418c2.19727 0 3.71094-1.46484 3.71094-3.61328 0-2.19727-1.51367-3.71094-3.71094-3.71094h-28.418c-2.24609 0-3.75977 1.51367-3.75977 3.71094 0 2.14844 1.51367 3.61328 3.75977 3.61328Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 281.506 1933)">
+   <path d="m58.5449 14.5508c27.4902 0 49.8047-22.3145 49.8047-49.8047s-22.3145-49.8047-49.8047-49.8047-49.8047 22.3145-49.8047 49.8047 22.3145 49.8047 49.8047 49.8047Zm0-8.30078c-22.9492 0-41.5039-18.5547-41.5039-41.5039s18.5547-41.5039 41.5039-41.5039 41.5039 18.5547 41.5039 41.5039-18.5547 41.5039-41.5039 41.5039Zm4.05273-23.0957v-36.9141c0-2.49023-1.70898-4.19922-4.15039-4.19922-2.39258 0-4.05273 1.70898-4.05273 4.19922v36.9141c0 2.44141 1.66016 4.15039 4.05273 4.15039 2.44141 0 4.15039-1.66016 4.15039-4.15039Zm-22.5586-14.4043h36.9629c2.44141 0 4.15039-1.61133 4.15039-4.00391 0-2.44141-1.70898-4.15039-4.15039-4.15039h-36.9629c-2.49023 0-4.15039 1.70898-4.15039 4.15039 0 2.39258 1.66016 4.00391 4.15039 4.00391Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 304.924 1933)">
+   <path d="m74.8535 28.3203c35.1074 0 63.623-28.4668 63.623-63.5742s-28.5156-63.623-63.623-63.623-63.5742 28.5156-63.5742 63.623 28.4668 63.5742 63.5742 63.5742Zm0-9.08203c-30.127 0-54.4922-24.3652-54.4922-54.4922s24.3652-54.4922 54.4922-54.4922 54.4922 24.3652 54.4922 54.4922-24.3652 54.4922-54.4922 54.4922Zm4.44336-30.3223v-48.4863c0-2.73438-1.85547-4.63867-4.54102-4.63867-2.58789 0-4.44336 1.9043-4.44336 4.63867v48.4863c0 2.68555 1.85547 4.58984 4.44336 4.58984 2.68555 0 4.54102-1.85547 4.54102-4.58984Zm-28.7109-19.7754h48.4863c2.68555 0 4.58984-1.80664 4.58984-4.39453 0-2.73438-1.85547-4.58984-4.58984-4.58984h-48.4863c-2.73438 0-4.58984 1.85547-4.58984 4.58984 0 2.58789 1.85547 4.39453 4.58984 4.39453Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 1953)">Design Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1971)">Symbols are supported in up to nine weights and three scales.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1989)">For optimal layout with text and other symbols, vertically align</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 2007)">symbols with the adjacent text.</text>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="776" x2="776" y1="1919" y2="1933"/>
+  <g transform="matrix(0.2 0 0 0.2 776 1933)">
+   <path d="m16.5527 0.78125c2.58789 0 3.85742-0.976562 4.78516-3.71094l20.5566-57.5195h0.244141l20.6055 57.5195c0.927734 2.73438 2.19727 3.71094 4.73633 3.71094 2.58789 0 4.24805-1.5625 4.24805-4.00391 0-0.830078-0.146484-1.61133-0.537109-2.63672l-22.9004-60.9863c-1.12305-2.97852-3.125-4.49219-6.25-4.49219-3.02734 0-5.07812 1.46484-6.15234 4.44336l-22.9004 61.084c-0.390625 1.02539-0.537109 1.80664-0.537109 2.63672 0 2.44141 1.5625 3.95508 4.10156 3.95508Zm10.2051-20.9473h30.6641c2.00195 0 3.66211-1.66016 3.66211-3.66211 0-2.05078-1.66016-3.66211-3.66211-3.66211h-30.6641c-2.00195 0-3.66211 1.61133-3.66211 3.66211 0 2.00195 1.66016 3.66211 3.66211 3.66211Z"/>
+  </g>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="792.836" x2="792.836" y1="1919" y2="1933"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 776 1953)">Margins</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1971)">Leading and trailing margins on the left and right side of each symbol</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1989)">can be adjusted by modifying the x-location of the margin guidelines.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2007)">Modifications are automatically applied proportionally to all</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2025)">scales and weights.</text>
+  <g transform="matrix(0.2 0 0 0.2 1289 1933)">
+   <path d="m14.209 13.1348 7.86133 7.86133c4.29688 4.39453 9.32617 4.10156 13.8672-1.02539l60.6934-68.2129-4.88281-4.88281-60.2539 67.6758c-1.80664 1.95312-3.4668 2.44141-5.81055 0.0976562l-5.17578-5.12695c-2.29492-2.29492-1.80664-3.95508 0.195312-5.81055l67.4805-62.1582-4.88281-4.83398-68.0664 62.5977c-4.98047 4.58984-5.32227 9.47266-1.02539 13.8184Zm44.873-97.4609c-2.05078 2.00195-2.24609 4.88281-1.07422 6.78711 1.12305 1.80664 3.4668 3.02734 6.5918 2.24609 5.85938-1.66016 12.5977-2.39258 18.8965 0.927734l-2.68555 7.12891c-1.61133 4.00391-0.732422 6.88477 1.70898 9.42383l10.2539 10.3027c2.34375 2.39258 4.54102 2.44141 7.08008 1.95312l4.44336-0.732422 2.58789 2.53906-0.195312 2.24609c-0.0976562 2.29492 0.537109 4.29688 2.7832 6.49414l3.36914 3.32031c2.29492 2.29492 5.51758 2.49023 7.8125 0.195312l12.9883-13.0371c2.29492-2.34375 2.14844-5.37109-0.195312-7.66602l-3.41797-3.41797c-2.19727-2.19727-4.05273-3.02734-6.34766-2.88086l-2.34375 0.244141-2.44141-2.44141 1.02539-4.6875c0.634766-2.73438-0.244141-4.98047-2.88086-7.61719l-11.2793-11.1816c-12.9395-12.8418-35.5957-11.0352-46.6797-0.146484Zm7.08008 2.05078c8.78906-6.39648 25.9766-5.66406 33.6914 1.95312l12.3047 12.207c1.02539 1.02539 1.2207 1.80664 0.927734 3.32031l-1.46484 6.64062 6.73828 6.68945 4.39453-0.244141c1.12305-0.0488281 1.51367 0.0488281 2.34375 0.878906l2.53906 2.49023-10.8398 10.8398-2.49023-2.49023c-0.830078-0.878906-0.976562-1.2207-0.927734-2.39258l0.292969-4.3457-6.68945-6.73828-6.83594 1.17188c-1.41602 0.292969-2.05078 0.195312-3.17383-0.878906l-8.93555-8.88672c-1.07422-1.02539-1.17188-1.70898-0.488281-3.36914l4.58984-11.4746c-6.10352-6.34766-17.041-7.51953-25.5859-4.58984-0.683594 0.244141-0.927734-0.390625-0.390625-0.78125Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 1289 1953)">Exporting</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1971)">Symbols should be outlined when exporting to ensure the</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1989)">design is preserved when submitting to Xcode.</text>
+  <text id="template-version" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1933)">Template v.7.0</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1951)">Requires Xcode 17 or greater</text>
+  <text id="descriptive-name" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1969)">Generated from bubble.right</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1987)">Typeset at 100.0 points</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 726)">Small</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1156)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1586)">Large</text>
+ </g>
+ <g id="Guides">
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 696)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="696" y2="696"/>
+  <line id="Capline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="625.541" y2="625.541"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1126)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1126" y2="1126"/>
+  <line id="Capline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1055.54" y2="1055.54"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1556)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1556" y2="1556"/>
+  <line id="Capline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1485.54" y2="1485.54"/>
+  <line id="right-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2989.45" x2="2989.45" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2877.35" x2="2877.35" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1502.16" x2="1502.16" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1397.53" x2="1397.53" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="609.873" x2="609.873" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="509.549" x2="509.549" y1="600.785" y2="720.121"/>
+ </g>
+ <g id="Symbols">
+  <g id="Black-S" transform="matrix(1 0 0 1 2877.35 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M72.2656 10.3516C77.2949 10.3516 80.4688 7.03125 80.4688 1.46484L80.4688-5.37109L83.6914-5.37109C93.2617-5.37109 102.344-13.4766 102.344-25.4883L102.344-57.1289C102.344-69.1406 94.2383-77.2461 82.2266-77.2461L29.8828-77.2461C17.8711-77.2461 9.76562-69.1406 9.76562-57.1289L9.76562-25.4883C9.76562-13.4766 17.8711-5.37109 29.8828-5.37109L49.0723-5.37109L61.6699 5.46875C65.8691 9.08203 68.8477 10.3516 72.2656 10.3516ZM68.9453-5.17578L57.2754-16.4551C54.834-18.7988 53.5645-19.5312 50.3418-19.5312L31.1523-19.5312C26.4648-19.5312 23.9258-21.875 23.9258-26.7578L23.9258-55.8594C23.9258-60.7422 26.4648-63.0859 31.1523-63.0859L80.957-63.0859C85.6445-63.0859 88.1836-60.7422 88.1836-55.8594L88.1836-26.7578C88.1836-21.875 85.6445-19.5312 80.957-19.5312L73.2422-19.5312C70.7031-19.5312 68.9453-18.3594 68.9453-15.2344Z"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:primary SFSymbolsPreviewWireframe" d="M56.4931-19.8665C58.2304-19.8665 59.6003-21.2333 59.6292-22.9766L59.8028-35.7642L64.9954-40.6376C67.4424-40.6808 69.8199-41.7426 71.5333-43.5717L58.4129-56.6936C56.5838-54.9543 55.4949-52.5467 55.4731-50.0707L37.8808-31.3485C36.8515-30.2765 36.9582-29.1906 38.0474-27.5169L35.0802-23.8725C34.3797-23.0059 34.5517-21.8012 35.3285-21.0259L35.89-20.4644C36.6928-19.6601 37.9019-19.517 38.8204-20.2694L42.378-23.2017C44.0683-22.1155 45.1118-22.0408 46.1883-23.0395L53.3585-29.7482L53.3585-22.9766C53.3585-21.2333 54.7528-19.8665 56.4931-19.8665ZM42.622-29.1962L57.5875-44.3212C57.8121-44.0547 58.098-43.7881 58.3567-43.5444C58.6458-43.2703 58.9245-43.0284 59.1941-42.7475L44.0634-27.7579ZM61.4228-59.6791L74.5462-46.5542C78.1167-49.9556 78.7883-55.5792 74.6356-59.7669C70.4479-63.9286 64.8227-63.251 61.4228-59.6791Z"/>
+  </g>
+  <g id="Regular-S" transform="matrix(1 0 0 1 1397.53 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M70.3613 7.37305C73.4375 7.37305 75.0977 5.22461 75.0977 1.85547L75.0977-7.86133L76.5625-7.86133C88.5742-7.86133 94.873-14.3555 94.873-26.1719L94.873-54.5898C94.873-66.4062 88.5742-72.9004 76.5625-72.9004L28.0762-72.9004C16.0645-72.9004 9.76562-66.4062 9.76562-54.5898L9.76562-26.1719C9.76562-14.3555 16.0645-7.86133 28.0762-7.86133L50.9766-7.86133L64.0625 3.85742C66.748 6.25 68.2129 7.37305 70.3613 7.37305ZM68.5547-0.634766L56.543-12.8906C54.9805-14.5508 53.7598-14.8926 51.416-14.8926L28.0762-14.8926C20.2148-14.8926 16.7969-18.6523 16.7969-26.1719L16.7969-54.5898C16.7969-62.0605 20.2148-65.8203 28.0762-65.8203L76.5625-65.8203C84.4238-65.8203 87.8418-62.0605 87.8418-54.5898L87.8418-26.1719C87.8418-18.6523 84.4238-14.8926 76.5625-14.8926L71.8262-14.8926C69.4336-14.8926 68.5547-14.0137 68.5547-11.6211Z"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:primary SFSymbolsPreviewWireframe" d="M52.8492-21.1551C54.1935-21.1551 55.2558-22.2158 55.2679-23.5633L55.3407-37.1132L60.7878-42.1866C63.0739-42.0662 65.37-43.0047 67.1852-44.8685L55.4932-56.576C53.6294-54.7503 52.6763-52.438 52.8194-50.1398L35.1081-31.191C34.265-30.2729 34.1909-29.1448 35.1555-27.9343L32.5441-24.595C32.0911-24.0291 32.1483-23.2048 32.7056-22.6336L33.2671-22.0721C33.835-21.5182 34.647-21.4436 35.2634-21.9471L38.5662-24.5431C39.7709-23.5802 40.8944-23.668 41.8002-24.5129L50.4166-32.5265L50.4166-23.5633C50.4166-22.2158 51.5033-21.1551 52.8492-21.1551ZM38.4737-29.2845L54.4138-45.8542C54.6916-45.4647 55.0066-45.1046 55.3659-44.7534C55.7235-44.404 56.0901-44.0797 56.4518-43.7933L39.9197-27.8401ZM57.9901-59.078L69.6838-47.3689C73.1043-50.7043 73.4569-55.5936 69.8288-59.2076C66.2149-62.811 61.3395-62.4846 57.9901-59.078Z"/>
+  </g>
+  <g id="Ultralight-S" transform="matrix(1 0 0 1 509.549 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M71.3603 4.10354C72.3023 4.10354 73.0088 3.40822 73.0088 2.26416L73.0088-8.6787L76.5625-8.6787C85.1231-8.6787 90.5591-14.1284 90.5591-22.6753L90.5591-56.043C90.5591-64.5899 85.1231-70.0396 76.5625-70.0396L23.7622-70.0396C15.2017-70.0396 9.76562-64.499 9.76562-56.043L9.76562-22.6753C9.76562-14.2192 15.2017-8.6787 23.7622-8.6787L55.563-8.6787L69.4663 3.17627C70.1084 3.70705 70.665 4.10354 71.3603 4.10354ZM70.916 1.68113L57.6782-9.89358C56.7515-10.6909 56.2119-10.8965 55.185-10.8965L23.8531-10.8965C16.7637-10.8965 11.9834-15.5645 11.9834-22.7661L11.9834-55.9521C11.9834-63.1958 16.7637-67.8183 23.8531-67.8183L76.4717-67.8183C83.7427-67.8183 88.3413-63.1958 88.3413-55.9521L88.3413-22.7661C88.3413-15.5645 83.7427-10.8965 76.4717-10.8965L72.0078-10.8965C71.25-10.8965 70.916-10.5625 70.916-9.8047Z"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:primary SFSymbolsPreviewWireframe" d="M50.4888-22.2212C51.294-22.2212 51.8938-22.8354 51.8938-23.6118L51.8938-37.9678L57.7349-43.3507C59.9797-42.977 62.4273-43.9467 64.6914-46.2107L54.4066-56.4911C52.1425-54.2127 51.3024-51.909 51.7149-49.6642L33.9026-30.4616C33.209-29.6848 33.2296-28.7964 34.2092-27.8455L31.5245-24.5766C31.3854-24.3931 31.3898-24.1438 31.5933-23.9302L32.1549-23.3687C32.3728-23.1608 32.5977-23.1507 32.8156-23.3242L36.0845-26.0377C36.9534-25.0437 37.9094-25.0088 38.6619-25.7124L49.0738-35.3444L49.0738-23.6118C49.0738-22.8354 49.698-22.2212 50.4888-22.2212ZM35.0132-29.2132L52.3931-47.7423C52.7393-47.0238 53.2106-46.3109 53.8227-45.6268C54.4249-44.9528 55.0802-44.4039 55.7786-44.0533L37.4234-26.7885ZM55.8874-57.9532L66.1578-47.6872C69.6652-51.1701 69.7873-55.2136 66.5834-58.3831C63.4139-61.5382 59.3804-61.4506 55.8874-57.9532Z"/>
+  </g>
+ </g>
+</svg>

--- a/Utilities/Constants.swift
+++ b/Utilities/Constants.swift
@@ -79,6 +79,7 @@ enum Icons {
     static let customLossless = "custom.lossless"
     static let customMusicNoteRectangleStack = "custom.music.note.rectangle.stack"
     static let customMusicNoteRectangleStackFill = "custom.music.note.rectangle.stack.fill"
+    static let customLyrics = "custom.music.microphone.bubble.right"
 }
 
 // MARK: - About

--- a/Views/Main/PlayerView.swift
+++ b/Views/Main/PlayerView.swift
@@ -5,7 +5,7 @@ struct PlayerView: View {
     @EnvironmentObject var playbackManager: PlaybackManager
     @EnvironmentObject var playbackProgressState: PlaybackProgressState
     @EnvironmentObject var playlistManager: PlaylistManager
-    @Binding var showingQueue: Bool
+    @Binding var rightSidebarContent: RightSidebarContent
     
     @Environment(\.scenePhase)
     var scenePhase
@@ -65,6 +65,7 @@ struct PlayerView: View {
         HStack(spacing: 12) {
             volumeControl
             queueButton
+            lyricsButton
         }
         .frame(width: 250, alignment: .trailing)
     }
@@ -384,23 +385,46 @@ struct PlayerView: View {
 
     private var queueButton: some View {
         Button(action: {
-            showingQueue.toggle()
+            rightSidebarContent = rightSidebarContent == .queue ? .none : .queue
         }) {
             Image(systemName: "list.bullet")
                 .font(.system(size: 16))
-                .foregroundColor(showingQueue ? .white : .secondary)
+                .foregroundColor(rightSidebarContent == .queue ? .white : .secondary)
                 .frame(width: 32, height: 32)
                 .background(
                     Circle()
-                        .fill(showingQueue ? Color.accentColor : Color.secondary.opacity(0.1))
+                        .fill(rightSidebarContent == .queue ? Color.accentColor : Color.secondary.opacity(0.1))
                 )
         }
         .buttonStyle(PlainButtonStyle())
         .hoverEffect(scale: 1.1)
-        .help(showingQueue ? "Hide Queue" : "Show Queue")
+        .help(rightSidebarContent == .queue ? "Hide Queue" : "Show Queue")
+    }
+    
+    private var lyricsButton: some View {
+        Button(action: {
+            rightSidebarContent = rightSidebarContent == .lyrics ? .none : .lyrics
+        }) {
+            Image(Icons.customLyrics)
+                .foregroundColor(rightSidebarContent == .lyrics ? .white : .secondary)
+                .frame(width: 32, height: 32)
+                .background(
+                    Circle()
+                        .fill(rightSidebarContent == .lyrics ? Color.accentColor : Color.secondary.opacity(0.1))
+                )
+        }
+        .buttonStyle(PlainButtonStyle())
+        .disabled(!hasCurrentTrack)
+        .opacity(hasCurrentTrack ? 1.0 : 0.5)
+        .hoverEffect(scale: hasCurrentTrack ? 1.1 : 1.0)
+        .help(rightSidebarContent == .lyrics ? "Hide Lyrics" : "Show Lyrics")
     }
 
     // MARK: - Computed Properties
+    
+    private var hasCurrentTrack: Bool {
+        playbackManager.currentTrack != nil
+    }
 
     private var progressPercentage: Double {
         guard let duration = playbackManager.currentTrack?.duration, duration > 0 else { return 0 }
@@ -612,10 +636,10 @@ private struct PlayPauseIcon: View {
 
 #Preview {
     struct PreviewWrapper: View {
-        @State private var showingQueue = false
+        @State private var rightSidebarContent: RightSidebarContent = .none
 
         var body: some View {
-            PlayerView(showingQueue: $showingQueue)
+            PlayerView(rightSidebarContent: $rightSidebarContent)
                 .environmentObject({
                     let coordinator = AppCoordinator()
                     return coordinator.playbackManager

--- a/Views/Main/TrackLyricsView.swift
+++ b/Views/Main/TrackLyricsView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+struct TrackLyricsView: View {
+    let track: Track
+    let onClose: () -> Void
+    
+    @EnvironmentObject var libraryManager: LibraryManager
+    
+    @State private var lyrics: String = ""
+    @State private var isLoading = true
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            header
+            
+            Divider()
+            
+            // Lyrics content
+            if isLoading {
+                loadingView
+            } else if lyrics.isEmpty {
+                emptyLyricsView
+            } else {
+                lyricsContent
+            }
+        }
+        .onAppear {
+            loadLyrics()
+        }
+    }
+    
+    // MARK: - Header
+    
+    private var header: some View {
+        ListHeader {
+            HStack(spacing: 12) {
+                Button(action: onClose) {
+                    Image(systemName: Icons.xmarkCircleFill)
+                        .font(.system(size: 16))
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                
+                Text("Lyrics")
+                    .headerTitleStyle()
+            }
+            
+            Spacer()
+        }
+    }
+    
+    // MARK: - Loading View
+    
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(0.8)
+            
+            Text("Loading lyrics...")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    
+    // MARK: - Empty Lyrics View
+    
+    private var emptyLyricsView: some View {
+        VStack(spacing: 16) {
+            Image(Icons.customLyrics)
+                .font(.system(size: 48))
+                .foregroundColor(.gray)
+            
+            Text("No Lyrics Available")
+                .font(.headline)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    
+    // MARK: - Lyrics Content
+    
+    private var lyricsContent: some View {
+        ScrollView {
+            Text(lyrics)
+                .font(.system(size: 14))
+                .foregroundColor(.primary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(10)
+                .padding(20)
+                .textSelection(.enabled)
+        }
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func loadLyrics() {
+        Task {
+            do {
+                let result = try await LyricsLoader.loadLyrics(
+                    for: track,
+                    using: libraryManager.databaseManager.dbQueue
+                )
+                
+                await MainActor.run {
+                    lyrics = result.lyrics
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    lyrics = ""
+                    isLoading = false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds support for viewing track lyrics when present in an external file (LRC or SRT) or embedded in track metadata.

A couple of points to note around this feature;

- External lyrics file needs to be present in the same path and same name as the track, eg; `01 Have a Cigar.mp3` track needs to have `01 Have a Cigar.lrc` in the same location.
- The app will attempt to show lyrics from an external file when present, and fall back to embedded lyrics within track metadata.
- Syncing of lyrics with playback is not supported yet, so the timestamps are stripped while showing lyrics from an external file.

Fixes #42

<img width="1473" height="1053" alt="Screenshot 2025-12-04 at 11 42 38 AM" src="https://github.com/user-attachments/assets/b28f5c46-f993-4ab2-aae8-a0f8a327dbaf" />
