### PR TITLE
Sort album tracks by disc & track number by default

### DIFF
--- a/Views/Components/TrackView.swift
+++ b/Views/Components/TrackView.swift
@@ -6,10 +6,10 @@ struct TrackView: View {
     @Binding var selectedTrackID: UUID?
     let playlistID: UUID?
     let entityID: UUID?
+    @Binding var sortOrder: [KeyPathComparator<Track>]
     let onPlayTrack: (Track) -> Void
     let contextMenuItems: ([Track]) -> [ContextMenuItem]
     
-    @State private var sortOrder = [KeyPathComparator(\Track.title)]
     @EnvironmentObject var playbackManager: PlaybackManager
     
     @AppStorage("trackTableRowSize")
@@ -74,6 +74,7 @@ extension View {
 
 // MARK: - Preview
 #Preview("Tracks View") {
+    @Previewable @State var sortOrder = [KeyPathComparator(\Track.title)]
     let sampleTracks = (0..<5).map { i in
         var track = Track(url: URL(fileURLWithPath: "/path/to/sample\(i).mp3"))
         track.title = "Sample Song \(i)"
@@ -89,6 +90,7 @@ extension View {
         selectedTrackID: .constant(nil),
         playlistID: nil,
         entityID: nil,
+        sortOrder: $sortOrder,
         onPlayTrack: { track in
             Logger.debugPrint("Playing \(track.title)")
         },
@@ -99,6 +101,7 @@ extension View {
 }
 
 #Preview("Tracks View with Playlist") {
+    @Previewable @State var sortOrder = [KeyPathComparator(\Track.title)]
     let sampleTracks = (0..<10).map { i in
         var track = Track(url: URL(fileURLWithPath: "/path/to/sample\(i).mp3"))
         track.title = "Playlist Song \(i)"
@@ -116,6 +119,7 @@ extension View {
         selectedTrackID: .constant(nil),
         playlistID: nil,
         entityID: nil,
+        sortOrder: $sortOrder,
         onPlayTrack: { track in
             Logger.debugPrint("Playing \(track.title)")
         },

--- a/Views/Components/TrackViews/TrackTableView.swift
+++ b/Views/Components/TrackViews/TrackTableView.swift
@@ -304,6 +304,12 @@ struct TrackTableView: View {
     // MARK: - Helper Methods
     
     private func initializeSortedTracks() {
+        // Follow overridden sort order for entities
+        if entityID != nil {
+            sortedTracks = tracks.sorted(using: sortOrder)
+            return
+        }
+
         if let savedSort = UserDefaults.standard.dictionary(forKey: "trackTableSortOrder"),
            let key = savedSort["key"] as? String,
            let ascending = savedSort["ascending"] as? Bool {

--- a/Views/Folders/FoldersView.swift
+++ b/Views/Folders/FoldersView.swift
@@ -110,6 +110,7 @@ struct FoldersView: View {
             selectedTrackID: $selectedTrackID,
             playlistID: nil,
             entityID: nil,
+            sortOrder: $trackTableSortOrder,
             onPlayTrack: { track in
                 if selectedFolderNode != nil {
                     // For hierarchical view, we need to play from the track list

--- a/Views/Home/EntityDetailView.swift
+++ b/Views/Home/EntityDetailView.swift
@@ -33,6 +33,7 @@ struct EntityDetailView: View {
                     selectedTrackID: $selectedTrackID,
                     playlistID: nil,
                     entityID: entity.id,
+                    sortOrder: $trackTableSortOrder,
                     onPlayTrack: { track in
                         playTrack(track)
                     },
@@ -354,6 +355,19 @@ struct EntityDetailView: View {
         }
         
         self.tracks = fetchedTracks
+        
+        // Sort album tracks by disc/track number by default if those values exist
+        if entity is AlbumEntity {
+            let hasCompleteOrdering = fetchedTracks.allSatisfy { $0.trackNumber != nil && $0.trackNumber! > 0 }
+            
+            if hasCompleteOrdering {
+                trackTableSortOrder = [
+                    KeyPathComparator(\Track.sortableDiscNumber, order: .forward),
+                    KeyPathComparator(\Track.sortableTrackNumber, order: .forward)
+                ]
+            }
+        }
+        
         self.isLoading = false
     }
     

--- a/Views/Home/HomeView.swift
+++ b/Views/Home/HomeView.swift
@@ -171,6 +171,7 @@ struct HomeView: View {
                     selectedTrackID: $selectedTrackID,
                     playlistID: nil,
                     entityID: nil,
+                    sortOrder: $trackTableSortOrder,
                     onPlayTrack: { track in
                         playlistManager.playTrack(track, fromTracks: libraryManager.discoverTracks)
                         playlistManager.currentQueueSource = .library
@@ -227,6 +228,7 @@ struct HomeView: View {
                     selectedTrackID: $selectedTrackID,
                     playlistID: nil,
                     entityID: nil,
+                    sortOrder: $trackTableSortOrder,
                     onPlayTrack: { track in
                         playlistManager.playTrack(track, fromTracks: libraryManager.tracks)
                         playlistManager.currentQueueSource = .library
@@ -461,6 +463,7 @@ struct HomeView: View {
                             selectedTrackID: $selectedTrackID,
                             playlistID: nil,
                             entityID: nil,
+                            sortOrder: $trackTableSortOrder,
                             onPlayTrack: { track in
                                 playlistManager.playTrack(track, fromTracks: pinnedItemTracks)
                                 playlistManager.currentQueueSource = .library

--- a/Views/Library/LibraryView.swift
+++ b/Views/Library/LibraryView.swift
@@ -122,6 +122,7 @@ struct LibraryView: View {
                     selectedTrackID: $selectedTrackID,
                     playlistID: nil,
                     entityID: nil,
+                    sortOrder: $trackTableSortOrder,
                     onPlayTrack: { track in
                         playlistManager.playTrack(track, fromTracks: cachedFilteredTracks)
                         playlistManager.currentQueueSource = .library

--- a/Views/Playlists/PlaylistDetailView.swift
+++ b/Views/Playlists/PlaylistDetailView.swift
@@ -213,6 +213,7 @@ struct PlaylistDetailView: View {
                     selectedTrackID: $selectedTrackID,
                     playlistID: playlistID,
                     entityID: nil,
+                    sortOrder: $playlistSortOrder,
                     onPlayTrack: { track in
                         if let playlist = playlist,
                            let index = playlist.tracks.firstIndex(of: track) {


### PR DESCRIPTION
Sorts album tracks to follow album order (i.e. disc & track) by default while falling back to user defined sort order.

Fixes #157