### PR TITLE
Adds support for refreshing Discover tracks manually

### DIFF
--- a/Managers/Library/LMDiscover.swift
+++ b/Managers/Library/LMDiscover.swift
@@ -17,6 +17,10 @@ extension LibraryManager {
         return count > 0 ? count : 50
     }
     
+    var discoverLastUpdated: Date? {
+        userDefaults.object(forKey: Self.discoverLastUpdatedKey) as? Date
+    }
+    
     // MARK: - Methods
     
     func loadDiscoverTracks() {

--- a/Views/Components/ListHeader.swift
+++ b/Views/Components/ListHeader.swift
@@ -149,22 +149,38 @@ struct TrackListHeader<Trailing: View>: View {
     }
 }
 
-struct TrackListHeaderWithOptions: View {
+struct TrackListHeaderWithOptions<TrailingContent: View>: View {
     let title: String
     let subtitle: String?
     @Binding var sortOrder: [KeyPathComparator<Track>]
     @Binding var tableRowSize: TableRowSize
+    let trailingContent: TrailingContent
 
     init(
         title: String,
         subtitle: String? = nil,
         sortOrder: Binding<[KeyPathComparator<Track>]>,
-        tableRowSize: Binding<TableRowSize>
+        tableRowSize: Binding<TableRowSize>,
+        @ViewBuilder trailingContent: () -> TrailingContent
     ) {
         self.title = title
         self.subtitle = subtitle
         self._sortOrder = sortOrder
         self._tableRowSize = tableRowSize
+        self.trailingContent = trailingContent()
+    }
+    
+    init(
+        title: String,
+        subtitle: String? = nil,
+        sortOrder: Binding<[KeyPathComparator<Track>]>,
+        tableRowSize: Binding<TableRowSize>
+    ) where TrailingContent == EmptyView {
+        self.title = title
+        self.subtitle = subtitle
+        self._sortOrder = sortOrder
+        self._tableRowSize = tableRowSize
+        self.trailingContent = EmptyView()
     }
 
     var body: some View {
@@ -180,6 +196,8 @@ struct TrackListHeaderWithOptions: View {
             }
 
             Spacer()
+            
+            trailingContent
 
             TrackTableOptionsDropdown(
                 sortOrder: $sortOrder,

--- a/Views/Home/HomeView.swift
+++ b/Views/Home/HomeView.swift
@@ -146,7 +146,18 @@ struct HomeView: View {
                 title: "Discover",
                 sortOrder: $trackTableSortOrder,
                 tableRowSize: $trackTableRowSize
-            )
+            ) {
+                Button(action: {
+                    libraryManager.refreshDiscoverTracks()
+                }) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 14))
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.borderless)
+                .hoverEffect(scale: 1.1)
+                .help("Refresh Discover tracks")
+            }
             
             Divider()
 
@@ -185,6 +196,7 @@ struct HomeView: View {
                         )
                     }
                 )
+                .id(libraryManager.discoverLastUpdated)
             }
         }
         .onAppear {


### PR DESCRIPTION
Adds support for refreshing Discover tracks without doing workarounds (eg; changing count of discover and relaunching the app).

<img width="1399" height="304" alt="Screenshot 2026-02-04 at 5 47 51 PM" src="https://github.com/user-attachments/assets/0c3899a0-1a53-467f-b69e-64b05cc0aa45" />



Fixes #170