### PR TITLE
Update Top 25 Most Played smart playlist behaviour

### DIFF
--- a/Managers/Database/DMQueries.swift
+++ b/Managers/Database/DMQueries.swift
@@ -544,6 +544,16 @@ extension DatabaseManager {
     
     // MARK: - Helper Methods
     
+    /// Get the current play count for a track from the database
+    func getTrackPlayCount(trackId: Int64) async throws -> Int? {
+        try await dbQueue.read { db in
+            try Track
+                .filter(Track.Columns.trackId == trackId)
+                .select(Track.Columns.playCount, as: Int.self)
+                .fetchOne(db)
+        }
+    }
+    
     func trackExists(withId trackId: Int64) -> Bool {
         do {
             return try dbQueue.read { db in

--- a/Managers/Database/DMSmartPlaylistQueries.swift
+++ b/Managers/Database/DMSmartPlaylistQueries.swift
@@ -223,8 +223,12 @@ extension DatabaseManager {
             return column == numericValue
         case .greaterThan:
             return column > numericValue
+        case .greaterThanOrEqual:
+            return column >= numericValue
         case .lessThan:
             return column < numericValue
+        case .lessThanOrEqual:
+            return column <= numericValue
         default:
             return nil
         }

--- a/Managers/Database/DatabaseMigration.swift
+++ b/Managers/Database/DatabaseMigration.swift
@@ -110,6 +110,18 @@ struct DatabaseMigrator {
             }
             Logger.info("v5_add_lossless_column migration completed")
         }
+        
+        migrator.registerMigration("v6_update_most_played_criteria") { db in
+            try db.execute(
+                sql: """
+                    UPDATE playlists
+                    SET smart_criteria = REPLACE(smart_criteria, '"condition":"greaterThan"', '"condition":"greaterThanOrEqual"')
+                    WHERE name = ? AND type = 'smart'
+                    """,
+                arguments: [DefaultPlaylists.mostPlayed]
+            )
+            Logger.info("v6_update_most_played_criteria migration completed")
+        }
 
         // MARK: - Future Migrations
         // Add new migrations here as: migrator.registerMigration("v2_description") { db in ... }

--- a/Managers/Playlist/PMSmartPlaylistEvaluator.swift
+++ b/Managers/Playlist/PMSmartPlaylistEvaluator.swift
@@ -132,8 +132,12 @@ extension PlaylistManager {
             return value == numericRuleValue
         case .greaterThan:
             return value > numericRuleValue
+        case .greaterThanOrEqual:
+            return value >= numericRuleValue
         case .lessThan:
             return value < numericRuleValue
+        case .lessThanOrEqual:
+            return value <= numericRuleValue
         default:
             return false
         }

--- a/Models/Core/Playlist.swift
+++ b/Models/Core/Playlist.swift
@@ -20,7 +20,9 @@ struct SmartPlaylistCriteria: Codable {
         case startsWith
         case endsWith
         case greaterThan
+        case greaterThanOrEqual
         case lessThan
+        case lessThanOrEqual
     }
     
     struct Rule: Codable {
@@ -427,14 +429,14 @@ extension Playlist {
                 isUserEditable: false
             ),
             
-            // Top 25 Most Played - already correct
+            // Top 25 Most Played - tracks played 5 or more times
             Playlist(
                 name: DefaultPlaylists.mostPlayed,
                 criteria: SmartPlaylistCriteria(
                     rules: [
                         SmartPlaylistCriteria.Rule(
                             field: "playCount",
-                            condition: .greaterThan,
+                            condition: .greaterThanOrEqual,
                             value: "5"
                         )
                     ],

--- a/Utilities/Constants.swift
+++ b/Utilities/Constants.swift
@@ -224,7 +224,7 @@ extension DefaultPlaylists {
             case DefaultPlaylists.favorites:
                 return "Mark songs as favorites to see them here"
             case DefaultPlaylists.mostPlayed:
-                return "Songs played more than 5 times will appear here"
+                return "Songs played 5 or more times will appear here"
             case DefaultPlaylists.recentlyPlayed:
                 return "Songs played in the last week will appear here"
             default:

--- a/Views/Playlists/PlaylistSidebarView.swift
+++ b/Views/Playlists/PlaylistSidebarView.swift
@@ -169,7 +169,7 @@ struct PlaylistSidebarView: View {
                 criteria: SmartPlaylistCriteria(
                     rules: [SmartPlaylistCriteria.Rule(
                         field: "playCount",
-                        condition: .greaterThan,
+                        condition: .greaterThanOrEqual,
                         value: "5"
                     )],
                     limit: 25,


### PR DESCRIPTION
Updates "Top 25 Most Played" smart playlist evaluation logic to include tracks that are played for 5 or more times. It also refreshes the playlist reliably without having to relaunch the app.

Fixes #163