### PR TITLE
Fix context menu closing during playback

### DIFF
--- a/Views/Main/PlayerView.swift
+++ b/Views/Main/PlayerView.swift
@@ -93,67 +93,12 @@ struct PlayerView: View {
     }
 
     private var trackDetails: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            // Title row with favorite button
-            HStack(alignment: .center, spacing: 8) {
-                Text(playbackManager.currentTrack?.title ?? "")
-                    .font(.system(size: 14, weight: .medium))
-                    .lineLimit(1)
-                    .foregroundColor(.primary)
-                    .truncationMode(.tail)
-                    .help(playbackManager.currentTrack?.title ?? "")
-                    .contextMenu {
-                        TrackContextMenuContent(items: currentTrackContextMenuItems)
-                    }
-
-                favoriteButton
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            // Artist with marquee
-            MarqueeText(
-                text: playbackManager.currentTrack?.artist ?? "",
-                font: .system(size: 12),
-                color: .secondary
-            )
-            .frame(height: 16)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contextMenu {
-                TrackContextMenuContent(items: currentTrackContextMenuItems)
-            }
-
-            // Album with marquee
-            MarqueeText(
-                text: playbackManager.currentTrack?.album ?? "",
-                font: .system(size: 11),
-                color: .secondary
-            )
-            .frame(height: 14)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contextMenu {
-                TrackContextMenuContent(items: currentTrackContextMenuItems)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private var favoriteButton: some View {
-        Group {
-            if let track = playbackManager.currentTrack {
-                Button(action: {
-                    playlistManager.toggleFavorite(for: track)
-                }) {
-                    Image(systemName: track.isFavorite ? Icons.starFill : Icons.star)
-                        .font(.system(size: 12))
-                        .foregroundColor(track.isFavorite ? .yellow : .secondary)
-                        .animation(.easeInOut(duration: 0.2), value: track.isFavorite)
-                }
-                .buttonStyle(.plain)
-                .focusable(false)
-                .hoverEffect(scale: 1.15)
-                .help(track.isFavorite ? "Remove from Favorites" : "Add to Favorites")
-            }
-        }
+        PlayerTrackDetailsView(
+            track: playbackManager.currentTrack,
+            contextMenuItems: currentTrackContextMenuItems,
+            playlistManager: playlistManager
+        )
+        .equatable()
     }
 
     // MARK: - Center Section Components
@@ -534,6 +479,89 @@ struct PlayerView: View {
 // Keep the existing supporting views and structs below...
 
 // MARK: - Album Art
+
+struct PlayerTrackDetailsView: View, Equatable {
+    let track: Track?
+    let contextMenuItems: [ContextMenuItem]
+    let playlistManager: PlaylistManager
+
+    static func == (lhs: PlayerTrackDetailsView, rhs: PlayerTrackDetailsView) -> Bool {
+        lhs.track?.id == rhs.track?.id &&
+        lhs.track?.isFavorite == rhs.track?.isFavorite
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // Title row with favorite button
+            HStack(alignment: .center, spacing: 8) {
+                Text(track?.title ?? "")
+                    .font(.system(size: 14, weight: .medium))
+                    .lineLimit(1)
+                    .foregroundColor(.primary)
+                    .truncationMode(.tail)
+                    .help(track?.title ?? "")
+                    .contextMenu {
+                        TrackContextMenuContent(items: contextMenuItems)
+                    }
+
+                if let track = track {
+                    FavoriteButtonView(
+                        isFavorite: track.isFavorite,
+                        onToggle: { playlistManager.toggleFavorite(for: track) }
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Artist with marquee
+            MarqueeText(
+                text: track?.artist ?? "",
+                font: .system(size: 12),
+                color: .secondary
+            )
+            .frame(height: 16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contextMenu {
+                TrackContextMenuContent(items: contextMenuItems)
+            }
+
+            // Album with marquee
+            MarqueeText(
+                text: track?.album ?? "",
+                font: .system(size: 11),
+                color: .secondary
+            )
+            .frame(height: 14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contextMenu {
+                TrackContextMenuContent(items: contextMenuItems)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct FavoriteButtonView: View, Equatable {
+    let isFavorite: Bool
+    let onToggle: () -> Void
+
+    static func == (lhs: FavoriteButtonView, rhs: FavoriteButtonView) -> Bool {
+        lhs.isFavorite == rhs.isFavorite
+    }
+
+    var body: some View {
+        Button(action: onToggle) {
+            Image(systemName: isFavorite ? Icons.starFill : Icons.star)
+                .font(.system(size: 12))
+                .foregroundColor(isFavorite ? .yellow : .secondary)
+                .animation(.easeInOut(duration: 0.2), value: isFavorite)
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+        .hoverEffect(scale: 1.15)
+        .help(isFavorite ? "Remove from Favorites" : "Add to Favorites")
+    }
+}
 
 struct TrackArtworkInfo: Equatable {
     let id: UUID


### PR DESCRIPTION
Prevents context menu from closing immediately when right-clicking on current track in player bar during playback by extracting track details into equatable component that only re-renders on track changes.

Fixes #182