### PR TITLE
Fix album art context menu submenu hover during playback

### DIFF
--- a/Views/Main/PlayerView.swift
+++ b/Views/Main/PlayerView.swift
@@ -77,7 +77,10 @@ struct PlayerView: View {
             TrackArtworkInfo(id: track.id, artworkData: track.artworkData)
         }
 
-        return PlayerAlbumArtView(trackInfo: trackArtworkInfo) {
+        return PlayerAlbumArtView(
+            trackInfo: trackArtworkInfo,
+            contextMenuItems: currentTrackContextMenuItems
+        ) {
             if let currentTrack = playbackManager.currentTrack {
                 NotificationCenter.default.post(
                     name: NSNotification.Name("ShowTrackInfo"),
@@ -87,9 +90,6 @@ struct PlayerView: View {
             }
         }
         .equatable()
-        .contextMenu {
-            TrackContextMenuContent(items: currentTrackContextMenuItems)
-        }
     }
 
     private var trackDetails: some View {
@@ -574,6 +574,7 @@ struct TrackArtworkInfo: Equatable {
 
 struct PlayerAlbumArtView: View, Equatable {
     let trackInfo: TrackArtworkInfo?
+    let contextMenuItems: [ContextMenuItem]
     let onTap: (() -> Void)?
 
     static func == (lhs: PlayerAlbumArtView, rhs: PlayerAlbumArtView) -> Bool {
@@ -584,6 +585,9 @@ struct PlayerAlbumArtView: View, Equatable {
         AlbumArtworkImage(trackInfo: trackInfo)
             .onTapGesture {
                 onTap?()
+            }
+            .contextMenu {
+                TrackContextMenuContent(items: contextMenuItems)
             }
     }
 }


### PR DESCRIPTION
Moves `.contextMenu` inside `PlayerAlbumArtView` equatable boundary. Previously it was applied after `.equatable()`, causing the menu to rebuild every ~1s from the progress timer - breaking submenu hover.

Follow-up to #183 