### PR TITLE
Update onboarding library scan to happen in background

### DIFF
--- a/Managers/Database/DatabaseManager.swift
+++ b/Managers/Database/DatabaseManager.swift
@@ -16,6 +16,8 @@ class DatabaseManager: ObservableObject {
 
     let dbQueue: DatabaseQueue
     private let dbPath: String
+    private var lastStatusUpdateTime: Date = .distantPast
+    private let statusUpdateInterval: TimeInterval = 0.5
 
     // MARK: - Initialization
 
@@ -79,6 +81,16 @@ class DatabaseManager: ObservableObject {
     }
 
     // MARK: - Helper Methods
+    
+    internal func updateScanStatus(_ message: String) {
+        let now = Date()
+        guard now.timeIntervalSince(lastStatusUpdateTime) >= statusUpdateInterval else { return }
+        lastStatusUpdateTime = now
+        
+        Task { @MainActor in
+            self.scanStatusMessage = message
+        }
+    }
 
     /// Clean up database file and recreate schema
     /// Warning: This will delete all data!

--- a/Managers/Library/LMFolders.swift
+++ b/Managers/Library/LMFolders.swift
@@ -26,9 +26,11 @@ extension LibraryManager {
             for url in openPanel.urls {
                 // Create security bookmark
                 do {
-                    let bookmarkData = try url.bookmarkData(options: [.withSecurityScope],
-                                                            includingResourceValuesForKeys: nil,
-                                                            relativeTo: nil)
+                    let bookmarkData = try url.bookmarkData(
+                        options: [.withSecurityScope],
+                        includingResourceValuesForKeys: nil,
+                        relativeTo: nil
+                    )
                     urlsToAdd.append(url)
                     bookmarkDataMap[url] = bookmarkData
                     Logger.info("Created bookmark for folder - \(url.lastPathComponent) at \(url.path)")

--- a/Utilities/Constants.swift
+++ b/Utilities/Constants.swift
@@ -240,6 +240,11 @@ extension DefaultPlaylists {
 // MARK: - Global Event Notifications
 
 extension Notification.Name {
+    static let initialScanStarted = Notification.Name("initialScanStarted")
+    static let checkInitialScanThreshold = Notification.Name("checkInitialScanThreshold")
+    static let initialScanCompleted = Notification.Name("initialScanCompleted")
+    static let foldersAddedToDatabase = Notification.Name("foldersAddedToDatabase")
+
     static let libraryDataDidChange = Notification.Name("LibraryDataDidChange")
     static let goToLibraryFilter = Notification.Name("GoToLibraryFilter")
 

--- a/Views/Folders/FoldersView.swift
+++ b/Views/Folders/FoldersView.swift
@@ -16,7 +16,7 @@ struct FoldersView: View {
     private var trackTableRowSize: TableRowSize = .expanded
 
     var body: some View {
-        if libraryManager.folders.isEmpty {
+        if !libraryManager.shouldShowMainUI {
             NoMusicEmptyStateView(context: .mainWindow)
         } else {
             PersistentSplitView(

--- a/Views/Home/HomeView.swift
+++ b/Views/Home/HomeView.swift
@@ -35,7 +35,7 @@ struct HomeView: View {
     @Binding var isShowingEntities: Bool
     
     var body: some View {
-        if libraryManager.folders.isEmpty {
+        if !libraryManager.shouldShowMainUI {
             NoMusicEmptyStateView(context: .mainWindow)
         } else {
             PersistentSplitView(

--- a/Views/Library/LibraryView.swift
+++ b/Views/Library/LibraryView.swift
@@ -26,7 +26,7 @@ struct LibraryView: View {
 
     var body: some View {
         VStack {
-            if libraryManager.folders.isEmpty {
+            if !libraryManager.shouldShowMainUI {
                 NoMusicEmptyStateView(context: .mainWindow)
             } else {
                 // Main library view with sidebar

--- a/Views/Main/ContentView.swift
+++ b/Views/Main/ContentView.swift
@@ -183,7 +183,7 @@ struct ContentView: View {
 
     @ViewBuilder
     private var playerControls: some View {
-        if !libraryManager.folders.isEmpty {
+        if libraryManager.shouldShowMainUI {
             Divider()
 
             PlayerView(rightSidebarContent: $rightSidebarContent)
@@ -223,10 +223,10 @@ struct ContentView: View {
                     shouldFocus: shouldFocusSearch
                 )
                 .frame(width: 280)
-                .disabled(libraryManager.folders.isEmpty)
+                .disabled(!libraryManager.shouldShowMainUI)
                 
                 settingsButton
-                    .disabled(libraryManager.folders.isEmpty)
+                    .disabled(!libraryManager.shouldShowMainUI)
             }
         }
     }
@@ -258,7 +258,7 @@ struct ContentView: View {
                 shouldFocus: shouldFocusSearch
             )
             .frame(width: 280)
-            .disabled(libraryManager.folders.isEmpty)
+            .disabled(!libraryManager.shouldShowMainUI)
         }
     }
     

--- a/Views/Main/PlayerView.swift
+++ b/Views/Main/PlayerView.swift
@@ -506,9 +506,8 @@ struct PlayerTrackDetailsView: View, Equatable {
 
                 if let track = track {
                     FavoriteButtonView(
-                        isFavorite: track.isFavorite,
-                        onToggle: { playlistManager.toggleFavorite(for: track) }
-                    )
+                        isFavorite: track.isFavorite
+                    ) { playlistManager.toggleFavorite(for: track) }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Views/Playlists/PlaylistsView.swift
+++ b/Views/Playlists/PlaylistsView.swift
@@ -10,8 +10,7 @@ struct PlaylistsView: View {
     private var splitPosition: Double = 200
 
     var body: some View {
-        if libraryManager.folders.isEmpty {
-            // Show unified empty state when no music exists
+        if !libraryManager.shouldShowMainUI {
             NoMusicEmptyStateView(context: .mainWindow)
         } else {
             PersistentSplitView(


### PR DESCRIPTION
Updates library scanning to happen fully in background for smoother user onboarding having larger libraries.

<img width="423" height="532" alt="image" src="https://github.com/user-attachments/assets/5e14ed72-c955-414a-92b6-2ba97a162039" />
