### PR TITLE
Handle incorrect track durations gracefully

### DIFF
--- a/Core/MetadataExtractor.swift
+++ b/Core/MetadataExtractor.swift
@@ -56,8 +56,8 @@ class MetadataExtractor {
     ///   - url: The URL of the audio file
     ///   - externalArtwork: Optional external artwork to use if file has none
     /// - Returns: TrackMetadata containing all extracted information
-    static func extractMetadataSync(from url: URL, externalArtwork: Data? = nil)
-        -> TrackMetadata
+    static func extractMetadata(from url: URL, externalArtwork: Data? = nil)
+        async -> TrackMetadata
     {
         var metadata = TrackMetadata(url: url)
 
@@ -74,7 +74,7 @@ class MetadataExtractor {
         }
 
         // Extract audio properties
-        extractAudioProperties(from: audioFile.properties, into: &metadata)
+        await extractAudioProperties(from: audioFile.properties, into: &metadata)
 
         // Extract metadata
         extractMetadata(from: audioFile.metadata, into: &metadata)
@@ -151,10 +151,38 @@ class MetadataExtractor {
     private static func extractAudioProperties(
         from properties: AudioProperties,
         into metadata: inout TrackMetadata
-    ) {
+    ) async {
+        // Format/Codec
+        if let formatName = properties.formatName {
+            metadata.codec = formatName
+        }
+        
         // Duration (TimeInterval is a typealias for Double)
         if let duration = properties.duration {
             metadata.duration = duration
+        }
+
+        // For MPEG audio (MP3/MP2/MP1), TagLib falls back to bitrate estimation
+        // when no Xing/Info/VBRI header is present, which can be inaccurate.
+        // AVFoundation uses independent frame scanning and is more reliable for these formats.
+        let isMPEG = metadata.codec == "MP3" || metadata.codec?.hasPrefix("MPEG") == true
+        if isMPEG {
+            let asset = AVURLAsset(url: metadata.url)
+            let avDuration: Double
+            do {
+                let duration = try await asset.load(.duration)
+                avDuration = duration.seconds
+            } catch {
+                avDuration = 0
+            }
+            if avDuration.isFinite && avDuration > 0
+                && abs(avDuration - metadata.duration) > 1.0 {
+                Logger.warning(
+                    "MPEG duration mismatch for \(metadata.url.lastPathComponent) - " +
+                    "SFBAudioEngine: \(metadata.duration)s, AVAsset: \(avDuration)s. Using AVAsset value."
+                )
+                metadata.duration = avDuration
+            }
         }
 
         // Sample rate
@@ -175,11 +203,6 @@ class MetadataExtractor {
         // Bitrate
         if let bitrate = properties.bitrate {
             metadata.bitrate = Int(bitrate)
-        }
-
-        // Format/Codec
-        if let formatName = properties.formatName {
-            metadata.codec = formatName
         }
 
         // Extract lossless flag from decoder

--- a/Managers/Database/DMTrackProcessing.swift
+++ b/Managers/Database/DMTrackProcessing.swift
@@ -140,7 +140,7 @@ extension DatabaseManager {
                 // Fetch the full track for comparison and update
                 guard let existingFullTrack = try await existingTrack.fullTrack(using: dbQueue) else {
                     // If we can't get full track, treat as new
-                    let metadata = MetadataExtractor.extractMetadataSync(
+                    let metadata = await MetadataExtractor.extractMetadata(
                         from: fileURL,
                         externalArtwork: externalArtwork
                     )
@@ -153,7 +153,7 @@ extension DatabaseManager {
                 
                 // Re-extract complete metadata on hardRefresh
                 if hardRefresh {
-                    let metadata = MetadataExtractor.extractMetadataSync(
+                    let metadata = await MetadataExtractor.extractMetadata(
                         from: fileURL,
                         externalArtwork: externalArtwork
                     )
@@ -173,7 +173,7 @@ extension DatabaseManager {
                     
                     if timeDifference > 1.0 {
                         // File modified, extract fresh metadata
-                        let metadata = MetadataExtractor.extractMetadataSync(
+                        let metadata = await MetadataExtractor.extractMetadata(
                             from: fileURL,
                             externalArtwork: externalArtwork
                         )
@@ -194,7 +194,7 @@ extension DatabaseManager {
             }
             
             // New track - extract metadata
-            let metadata = MetadataExtractor.extractMetadataSync(
+            let metadata = await MetadataExtractor.extractMetadata(
                 from: fileURL,
                 externalArtwork: externalArtwork
             )

--- a/Managers/PlaybackManager.swift
+++ b/Managers/PlaybackManager.swift
@@ -237,9 +237,15 @@ class PlaybackManager: NSObject, ObservableObject {
     }
     
     func seekTo(time: Double) {
-        audioPlayer.seek(to: time)
-        currentTime = time
-        restoredPosition = time
+        // Clamp seek position to the engine's actual duration to prevent seek
+        // errors when the DB-stored duration differs from the actual track
+        // duration, this happens in edge-cases for MP3, although it is fixed
+        // in MetadataExtractor so hard refresh on library should resolve this.
+        let engineDuration = audioPlayer.duration
+        let clampedTime = engineDuration > 0 ? min(time, engineDuration) : time
+        audioPlayer.seek(to: clampedTime)
+        currentTime = clampedTime
+        restoredPosition = clampedTime
         
         NotificationCenter.default.post(
             name: NSNotification.Name("PlayerDidSeek"),


### PR DESCRIPTION
Fixes playback seeking on tracks where duration data stored in the db may be incorrect due to misreported duration in track metadata tags. Also adds a fallback to extract duration accurately in such cases.

Fixes #196