### PR TITLE
Fix importing of playlists with relative track paths

### DIFF
--- a/Managers/Database/DMQueries.swift
+++ b/Managers/Database/DMQueries.swift
@@ -547,13 +547,47 @@ extension DatabaseManager {
     func findTrackByPath(_ path: String) async -> Track? {
         do {
             return try await dbQueue.read { db in
-                try Track
+                if let track = try Track
                     .filter(Track.Columns.path == path)
+                    .fetchOne(db) {
+                    return track
+                }
+                return try Track
+                    .filter(Track.Columns.path.collating(.nocase) == path)
                     .fetchOne(db)
             }
         } catch {
             Logger.error("Failed to query track by path: \(error)")
             return nil
+        }
+    }
+
+    /// Find a track by its file name
+    func findTracksByFilenames(_ filenames: [String]) async -> [String: Track] {
+        do {
+            return try await dbQueue.read { db in
+                let lowercasedFilenames = filenames.map { $0.lowercased() }
+                let tracks = try Track
+                    .filter(lowercasedFilenames.contains(Track.Columns.filename.lowercased))
+                    .fetchAll(db)
+                var result: [String: Track] = [:]
+                var ambiguous: Set<String> = []
+                for track in tracks {
+                    let key = track.url.lastPathComponent.lowercased()
+                    if result[key] == nil {
+                        result[key] = track
+                    } else {
+                        ambiguous.insert(key)
+                    }
+                }
+                for key in ambiguous {
+                    result.removeValue(forKey: key)
+                }
+                return result
+            }
+        } catch {
+            Logger.error("Failed to query tracks by filenames: \(error)")
+            return [:]
         }
     }
 

--- a/Managers/Database/DMSetup.swift
+++ b/Managers/Database/DMSetup.swift
@@ -393,7 +393,10 @@ extension DatabaseManager {
         try db.createIndexIfNotExists(name: "idx_tracks_rating", table: "tracks", columns: ["rating"])
         try db.createIndexIfNotExists(name: "idx_tracks_compilation", table: "tracks", columns: ["compilation"])
         try db.createIndexIfNotExists(name: "idx_tracks_media_type", table: "tracks", columns: ["media_type"])
-        
+
+        // TODO: Uncomment in next minor release to add filename index for playlist import performance
+        // try db.createIndexIfNotExists(name: "idx_tracks_filename", table: "tracks", columns: ["filename"])
+
         // Duplicate tracking indices
         try db.createIndexIfNotExists(name: "idx_tracks_primary_track_id", table: "tracks", columns: ["primary_track_id"])
         try db.createIndexIfNotExists(name: "idx_tracks_is_duplicate", table: "tracks", columns: ["is_duplicate"])

--- a/Managers/Database/DatabaseMigration.swift
+++ b/Managers/Database/DatabaseMigration.swift
@@ -123,6 +123,16 @@ struct DatabaseMigrator {
             Logger.info("v6_update_most_played_criteria migration completed")
         }
 
+        // TODO: Uncomment in next minor release to add filename index for playlist import performance
+        // migrator.registerMigration("v7_add_filename_index_for_playlist_import") { db in
+        //     try db.createIndexIfNotExists(
+        //         name: "idx_tracks_filename",
+        //         table: "tracks",
+        //         columns: ["filename"]
+        //     )
+        //     Logger.info("v7_add_filename_index_for_playlist_import migration completed")
+        // }
+
         // MARK: - Future Migrations
         // Add new migrations here as: migrator.registerMigration("v2_description") { db in ... }
         

--- a/Managers/Playlist/PMImportExport.swift
+++ b/Managers/Playlist/PMImportExport.swift
@@ -116,6 +116,7 @@ extension PlaylistManager {
     
     private func importSinglePlaylist(from url: URL, usedNames: Set<String>) async -> PlaylistImportResult {
         let basePlaylistName = url.deletingPathExtension().lastPathComponent
+        let sourceDirectory = url.deletingLastPathComponent()
         
         let fileContent = (try? String(contentsOf: url, encoding: .utf8)) ??
                           (try? String(contentsOf: url, encoding: .isoLatin1))
@@ -131,10 +132,20 @@ extension PlaylistManager {
             )
         }
         
-        return await processM3UContent(content, playlistName: basePlaylistName, usedNames: usedNames)
+        return await processM3UContent(
+            content,
+            playlistName: basePlaylistName,
+            usedNames: usedNames,
+            sourceDirectory: sourceDirectory
+        )
     }
     
-    private func processM3UContent(_ content: String, playlistName: String, usedNames: Set<String>) async -> PlaylistImportResult {
+    private func processM3UContent(
+        _ content: String,
+        playlistName: String,
+        usedNames: Set<String>,
+        sourceDirectory: URL? = nil
+    ) async -> PlaylistImportResult {
         let trackPaths = parseM3UContent(content)
         
         guard !trackPaths.isEmpty else {
@@ -148,7 +159,10 @@ extension PlaylistManager {
             )
         }
         
-        let matchResult = await matchTracksToLibrary(trackPaths: trackPaths)
+        let matchResult = await matchTracksToLibrary(
+            trackPaths: trackPaths,
+            sourceDirectory: sourceDirectory
+        )
         
         guard !matchResult.matchedTracks.isEmpty else {
             Logger.error("Import failed - '\(playlistName)': 0/\(trackPaths.count) tracks found in library")
@@ -197,7 +211,10 @@ extension PlaylistManager {
             .filter { !$0.isEmpty && !$0.hasPrefix(M3UFormat.commentPrefix) }
     }
     
-    private func matchTracksToLibrary(trackPaths: [String]) async -> (matchedTracks: [Track], unmatchedPaths: [String]) {
+    private func matchTracksToLibrary(
+        trackPaths: [String],
+        sourceDirectory: URL? = nil
+    ) async -> (matchedTracks: [Track], unmatchedPaths: [String]) {
         guard let dbManager = libraryManager?.databaseManager else {
             return ([], trackPaths)
         }
@@ -206,7 +223,7 @@ extension PlaylistManager {
         var unmatchedPaths: [String] = []
         
         for originalPath in trackPaths {
-            let pathVariations = generatePathVariations(originalPath)
+            let pathVariations = generatePathVariations(originalPath, sourceDirectory: sourceDirectory)
             
             var matched = false
             for path in pathVariations {
@@ -222,11 +239,27 @@ extension PlaylistManager {
             }
         }
         
+        if !unmatchedPaths.isEmpty {
+            let filenames = unmatchedPaths.map { ($0 as NSString).lastPathComponent }
+            let filenameMap = await dbManager.findTracksByFilenames(filenames)
+            
+            var stillUnmatched: [String] = []
+            for path in unmatchedPaths {
+                let filename = (path as NSString).lastPathComponent.lowercased()
+                if let track = filenameMap[filename] {
+                    matchedTracks.append(track)
+                } else {
+                    stillUnmatched.append(path)
+                }
+            }
+            unmatchedPaths = stillUnmatched
+        }
+        
         return (matchedTracks, unmatchedPaths)
     }
     
     /// Generates possible path variations for M3U import matching
-    private func generatePathVariations(_ path: String) -> [String] {
+    private func generatePathVariations(_ path: String, sourceDirectory: URL? = nil) -> [String] {
         var normalized = path
         
         for scheme in ["file://", "smb://", "afp://", "nfs://"] {
@@ -241,17 +274,24 @@ extension PlaylistManager {
             normalized = "/Volumes" + String(normalized.dropFirst(1))
         }
         
+        normalized = normalized.replacingOccurrences(of: "\\", with: "/")
+        
         // URL decode
         normalized = normalized.removingPercentEncoding ?? normalized
         
         var variations = [normalized]
         
         if normalized.hasPrefix("/Volumes/") {
-            // Try without /Volumes prefix
             variations.append(String(normalized.dropFirst(8)))
         } else if normalized.hasPrefix("/") && !normalized.hasPrefix("/Users/") {
-            // Try with /Volumes prefix
             variations.append("/Volumes" + normalized)
+        } else if !normalized.hasPrefix("/"), let sourceDirectory {
+            var relativePath = normalized
+            while relativePath.hasPrefix("./") {
+                relativePath = String(relativePath.dropFirst(2))
+            }
+            let resolved = sourceDirectory.appendingPathComponent(relativePath).standardizedFileURL.path
+            variations.insert(resolved, at: 0)
         }
         
         return variations

--- a/Models/Core/Track.swift
+++ b/Models/Core/Track.swift
@@ -151,6 +151,7 @@ struct Track: Identifiable, Equatable, Hashable, FetchableRecord, PersistableRec
         static let trackId = Column("id")
         static let folderId = Column("folder_id")
         static let path = Column("path")
+        static let filename = Column("filename")
         static let title = Column("title")
         static let artist = Column("artist")
         static let album = Column("album")


### PR DESCRIPTION
Fix importing of playlists with relative track paths, along with the ability to do partial import in case only a few tracks from the playlist are present in the library.

Fixes #200