### PR TITLE
Fix playlist and its count not updating reliably

### DIFF
--- a/Managers/Playlist/PMRegularPlaylists.swift
+++ b/Managers/Playlist/PMRegularPlaylists.swift
@@ -119,6 +119,12 @@ extension PlaylistManager {
             return
         }
 
+        await MainActor.run {
+            if self.playlists[index].tracks.isEmpty, let dbManager = libraryManager?.databaseManager {
+                self.playlists[index].tracks = dbManager.loadTracksForPlaylist(playlistID)
+            }
+        }
+
         // Check if track already exists
         let alreadyExists = await MainActor.run {
             self.playlists[index].tracks.contains { $0.trackId == track.trackId }
@@ -132,6 +138,7 @@ extension PlaylistManager {
         // Add track on main thread
         await MainActor.run {
             self.playlists[index].addTrack(track)
+            self.playlists[index].trackCount = self.playlists[index].tracks.count
         }
 
         // Save to database - use efficient single track method


### PR DESCRIPTION
Fixes the following two annoyances when a track is added to an existing playlist;

- If that existing playlist that hasn't been viewed, the track list in it only shows that newly added track when opened for the first time, this is resolved only if the app is relaunched.
- Playlist track count doesn't update unless the app is relaunched