### PR TITLE
Fix default tracks order in Artists and Playlists

### DIFF
--- a/Managers/Playlist/PMRegularPlaylists.swift
+++ b/Managers/Playlist/PMRegularPlaylists.swift
@@ -40,11 +40,10 @@ extension PlaylistManager {
     
     /// Create a new basic playlist
     func createPlaylist(name: String, tracks: [Track] = []) -> Playlist {
-        var newPlaylist = Playlist(name: name, tracks: tracks)
-        newPlaylist.trackCount = tracks.count
+        let newPlaylist = Playlist(name: name, tracks: [])
         playlists.append(newPlaylist)
-        
-        // Save to database
+
+        // Save to database and add tracks
         Task {
             do {
                 if let dbManager = libraryManager?.databaseManager {
@@ -53,8 +52,12 @@ extension PlaylistManager {
             } catch {
                 Logger.error("Failed to save new playlist: \(error)")
             }
+
+            if !tracks.isEmpty {
+                await addTracksToPlaylist(tracks: tracks, playlistID: newPlaylist.id)
+            }
         }
-        
+
         return newPlaylist
     }
     
@@ -135,9 +138,11 @@ extension PlaylistManager {
             return
         }
 
-        // Add track on main thread
+        // Add track on main thread with playlist-specific dateAdded
         await MainActor.run {
-            self.playlists[index].addTrack(track)
+            var playlistTrack = track
+            playlistTrack.dateAdded = Date()
+            self.playlists[index].addTrack(playlistTrack)
             self.playlists[index].trackCount = self.playlists[index].tracks.count
         }
 
@@ -199,8 +204,14 @@ extension PlaylistManager {
                 return !existingTrackIds.contains(trackId)
             }
             
-            // Batch append all new tracks
-            self.playlists[index].tracks.append(contentsOf: newTracks)
+            // Batch append all new tracks with playlist-specific dateAdded
+            let now = Date()
+            let playlistTracks = newTracks.map { track -> Track in
+                var t = track
+                t.dateAdded = now
+                return t
+            }
+            self.playlists[index].tracks.append(contentsOf: playlistTracks)
             
             // Update metadata
             self.playlists[index].dateModified = Date()

--- a/Views/Components/TrackViews/TrackTableView.swift
+++ b/Views/Components/TrackViews/TrackTableView.swift
@@ -304,8 +304,8 @@ struct TrackTableView: View {
     // MARK: - Helper Methods
     
     private func initializeSortedTracks() {
-        // Follow overridden sort order for entities
-        if entityID != nil {
+        // Follow overridden sort order for entities and playlists
+        if entityID != nil || playlistID != nil {
             sortedTracks = tracks.sorted(using: sortOrder)
             return
         }

--- a/Views/Home/EntityDetailView.swift
+++ b/Views/Home/EntityDetailView.swift
@@ -32,7 +32,7 @@ struct EntityDetailView: View {
                     tracks: tracks,
                     selectedTrackID: $selectedTrackID,
                     playlistID: nil,
-                    entityID: entity.id,
+                    entityID: entity is ArtistEntity ? nil : entity.id,
                     sortOrder: $trackTableSortOrder,
                     onPlayTrack: { track in
                         playTrack(track)

--- a/Views/Playlists/PlaylistDetailView.swift
+++ b/Views/Playlists/PlaylistDetailView.swift
@@ -11,7 +11,7 @@ struct PlaylistDetailView: View {
     @AppStorage("trackTableRowSize")
     private var trackTableRowSize: TableRowSize = .expanded
     
-    @State private var playlistSortOrder = [KeyPathComparator(\Track.title)]
+    @State private var playlistSortOrder = [KeyPathComparator(\Track.sortableDateAdded)]
 
     // Convenience initializer for when you have a Playlist object
     init(playlist: Playlist) {


### PR DESCRIPTION
Fixes default tracks sort order where;

- In Artist view, user-set sort order is used
- In Playlist view, tracks are sorted by `Date added`