### PR TITLE
Use HEIC format to store album art

### DIFF
--- a/Core/MetadataExtractor.swift
+++ b/Core/MetadataExtractor.swift
@@ -80,7 +80,7 @@ class MetadataExtractor {
         extractMetadata(from: audioFile.metadata, into: &metadata)
 
         // Extract artwork
-        extractArtwork(from: audioFile.metadata, into: &metadata)
+        extractArtwork(from: audioFile.metadata, into: &metadata, source: url.lastPathComponent)
 
         // Use external artwork if no artwork found
         if metadata.artworkData == nil, let externalArtwork = externalArtwork {
@@ -136,7 +136,7 @@ class MetadataExtractor {
                     && AlbumArtFormat.isSupported(ext)
                 {
                     if let data = try? Data(contentsOf: url) {
-                        artworkMap[directory] = data
+                        artworkMap[directory] = ImageResizer.compressImage(from: data, source: url.path) ?? data
                         foundArtworkInCurrentDir = true
                     }
                 }
@@ -594,11 +594,13 @@ class MetadataExtractor {
 
     private static func extractArtwork(
         from audioMetadata: AudioMetadata,
-        into metadata: inout TrackMetadata
+        into metadata: inout TrackMetadata,
+        source: String? = nil
     ) {
         // Get the first attached picture
         if let firstPicture = audioMetadata.attachedPictures.first {
-            metadata.artworkData = firstPicture.imageData
+            metadata.artworkData = ImageResizer.compressImage(from: firstPicture.imageData, source: source)
+                ?? firstPicture.imageData
         }
     }
 

--- a/Managers/Database/DMBackgroundMigration.swift
+++ b/Managers/Database/DMBackgroundMigration.swift
@@ -14,7 +14,11 @@ extension DatabaseManager {
         do {
             pending = try await dbQueue.read { db -> [(String, String?)] in
                 if try db.tableExists("background_migrations") {
-                    return try Row.fetchAll(db, sql: "SELECT identifier, progress FROM background_migrations WHERE completed_at IS NULL ORDER BY identifier")
+                    let sql = """
+                        SELECT identifier, progress FROM background_migrations \
+                        WHERE completed_at IS NULL ORDER BY identifier
+                        """
+                    return try Row.fetchAll(db, sql: sql)
                         .map { ($0["identifier"], $0["progress"]) }
                 }
                 return []
@@ -27,9 +31,242 @@ extension DatabaseManager {
 
         for (identifier, progress) in pending {
             switch identifier {
+            case "v8_background_convert_artwork_to_heic":
+                await convertArtworkToHEIC(progress: progress)
             default:
                 Logger.warning("Unknown background migration: \(identifier)")
             }
+        }
+    }
+
+    // MARK: - v8: Convert Artwork to HEIC
+
+    private struct ArtworkConversionProgress: Codable {
+        let table: String
+        let offset: Int
+    }
+
+    private struct ArtworkTableOps: Sendable {
+        let name: String
+        let count: @Sendable (Database) throws -> Int
+        let fetchBatch: @Sendable (Database, Int, Int) throws -> [Row]
+        let compressAndUpdate: @Sendable (DatabaseQueue, [Row]) throws -> Int
+    }
+
+    private static let artworkMigrationIdentifier = "v8_background_convert_artwork_to_heic"
+
+    private static let artworkTableOps: [ArtworkTableOps] = [
+        ArtworkTableOps(
+            name: "albums",
+            count: { db in try Album.filter(Album.Columns.artworkData != nil).fetchCount(db) },
+            fetchBatch: { db, limit, offset in
+                try Row.fetchAll(db, Album
+                    .filter(Album.Columns.artworkData != nil)
+                    .select(Album.Columns.id, Album.Columns.title, Album.Columns.artworkData)
+                    .limit(limit, offset: offset))
+            },
+            compressAndUpdate: { dbQueue, rows in
+                var updates: [(Int64, Data)] = []
+                for row in rows {
+                    guard let rowId: Int64 = row[Album.Columns.id],
+                          let original: Data = row[Album.Columns.artworkData] else { continue }
+                    let name: String? = row[Album.Columns.title]
+                    guard let compressed = ImageResizer.compressImage(
+                        from: original, source: "album: \(name ?? "id=\(rowId)")"
+                    ) else { continue }
+                    guard compressed.count < original.count else { continue }
+                    updates.append((rowId, compressed))
+                }
+                try dbQueue.write { db in
+                    for (rowId, data) in updates {
+                        try Album.filter(Album.Columns.id == rowId)
+                            .updateAll(db, Album.Columns.artworkData.set(to: data))
+                    }
+                }
+                return updates.count
+            }
+        ),
+        ArtworkTableOps(
+            name: "artists",
+            count: { db in try Artist.filter(Artist.Columns.artworkData != nil).fetchCount(db) },
+            fetchBatch: { db, limit, offset in
+                try Row.fetchAll(db, Artist
+                    .filter(Artist.Columns.artworkData != nil)
+                    .select(Artist.Columns.id, Artist.Columns.name, Artist.Columns.artworkData)
+                    .limit(limit, offset: offset))
+            },
+            compressAndUpdate: { dbQueue, rows in
+                var updates: [(Int64, Data)] = []
+                for row in rows {
+                    guard let rowId: Int64 = row[Artist.Columns.id],
+                          let original: Data = row[Artist.Columns.artworkData] else { continue }
+                    let name: String? = row[Artist.Columns.name]
+                    guard let compressed = ImageResizer.compressImage(
+                        from: original, source: "artist: \(name ?? "id=\(rowId)")"
+                    ) else { continue }
+                    guard compressed.count < original.count else { continue }
+                    updates.append((rowId, compressed))
+                }
+                try dbQueue.write { db in
+                    for (rowId, data) in updates {
+                        try Artist.filter(Artist.Columns.id == rowId)
+                            .updateAll(db, Artist.Columns.artworkData.set(to: data))
+                    }
+                }
+                return updates.count
+            }
+        ),
+        ArtworkTableOps(
+            name: "tracks",
+            count: { db in try FullTrack.filter(FullTrack.Columns.trackArtworkData != nil).fetchCount(db) },
+            fetchBatch: { db, limit, offset in
+                try Row.fetchAll(db, FullTrack
+                    .filter(FullTrack.Columns.trackArtworkData != nil)
+                    .select(FullTrack.Columns.trackId, FullTrack.Columns.filename, FullTrack.Columns.trackArtworkData)
+                    .limit(limit, offset: offset))
+            },
+            compressAndUpdate: { dbQueue, rows in
+                var updates: [(Int64, Data)] = []
+                for row in rows {
+                    guard let rowId: Int64 = row[FullTrack.Columns.trackId],
+                          let original: Data = row[FullTrack.Columns.trackArtworkData] else { continue }
+                    let name: String? = row[FullTrack.Columns.filename]
+                    guard let compressed = ImageResizer.compressImage(
+                        from: original, source: "track: \(name ?? "id=\(rowId)")"
+                    ) else { continue }
+                    guard compressed.count < original.count else { continue }
+                    updates.append((rowId, compressed))
+                }
+                try dbQueue.write { db in
+                    for (rowId, data) in updates {
+                        try FullTrack.filter(FullTrack.Columns.trackId == rowId)
+                            .updateAll(db, FullTrack.Columns.trackArtworkData.set(to: data))
+                    }
+                }
+                return updates.count
+            }
+        ),
+        ArtworkTableOps(
+            name: "playlists",
+            count: { db in try Playlist.filter(Playlist.Columns.coverArtworkData != nil).fetchCount(db) },
+            fetchBatch: { db, limit, offset in
+                try Row.fetchAll(db, Playlist
+                    .filter(Playlist.Columns.coverArtworkData != nil)
+                    .select(Playlist.Columns.id, Playlist.Columns.name, Playlist.Columns.coverArtworkData)
+                    .limit(limit, offset: offset))
+            },
+            compressAndUpdate: { dbQueue, rows in
+                var updates: [(String, Data)] = []
+                for row in rows {
+                    guard let rowId: String = row[Playlist.Columns.id],
+                          let original: Data = row[Playlist.Columns.coverArtworkData] else { continue }
+                    let name: String? = row[Playlist.Columns.name]
+                    guard let compressed = ImageResizer.compressImage(
+                        from: original, source: "playlist: \(name ?? "id=\(rowId)")"
+                    ) else { continue }
+                    guard compressed.count < original.count else { continue }
+                    updates.append((rowId, compressed))
+                }
+                try dbQueue.write { db in
+                    for (rowId, data) in updates {
+                        try Playlist.filter(Playlist.Columns.id == rowId)
+                            .updateAll(db, Playlist.Columns.coverArtworkData.set(to: data))
+                    }
+                }
+                return updates.count
+            }
+        )
+    ]
+
+    private func convertArtworkToHEIC(progress: String?) async {
+        NotificationManager.shared.startActivity("Optimizing Library...")
+
+        let sizeBefore = getDatabaseSize() ?? 0
+        let batchSize = 50
+        let tables = Self.artworkTableOps
+
+        var resumeTable = tables[0].name
+        var resumeOffset = 0
+        if let progress = progress,
+           let data = progress.data(using: .utf8),
+           let state = try? JSONDecoder().decode(ArtworkConversionProgress.self, from: data) {
+            resumeTable = state.table
+            resumeOffset = state.offset
+            Logger.info("Resuming artwork optimization from \(resumeTable) at offset \(resumeOffset)")
+        }
+
+        let startIndex = tables.firstIndex { $0.name == resumeTable } ?? 0
+
+        do {
+            let totalRows = try await dbQueue.read { db -> Int in
+                try tables.reduce(0) { total, table in try total + table.count(db) }
+            }
+
+            Logger.info("Starting artwork optimization: \(totalRows) total rows")
+
+            try await Task.detached(priority: .utility) { [dbQueue, weak self] in
+                guard let self = self else { return }
+
+                var totalProcessed = 0
+                if startIndex > 0 || resumeOffset > 0 {
+                    totalProcessed = try dbQueue.read { db -> Int in
+                        var processed = 0
+                        for tableIdx in 0..<startIndex {
+                            processed += try tables[tableIdx].count(db)
+                        }
+                        return processed + resumeOffset
+                    }
+                    NotificationManager.shared.updateActivityProgress(current: totalProcessed, total: totalRows)
+                }
+
+                for tableIndex in startIndex..<tables.count {
+                    let ops = tables[tableIndex]
+                    var offset = (tableIndex == startIndex) ? resumeOffset : 0
+                    var converted = 0
+                    var skipped = 0
+
+                    while true {
+                        let rows = try dbQueue.read { db in try ops.fetchBatch(db, batchSize, offset) }
+                        if rows.isEmpty { break }
+
+                        let batchConverted = try ops.compressAndUpdate(dbQueue, rows)
+                        converted += batchConverted
+                        skipped += rows.count - batchConverted
+                        totalProcessed += rows.count
+                        offset += batchSize
+
+                        NotificationManager.shared.updateActivityProgress(current: totalProcessed, total: totalRows)
+                        if let progressData = try? JSONEncoder().encode(
+                            ArtworkConversionProgress(table: ops.name, offset: offset)
+                        ),
+                           let progressJson = String(data: progressData, encoding: .utf8) {
+                            self.updateMigrationProgress(Self.artworkMigrationIdentifier, progress: progressJson)
+                        }
+                    }
+
+                    let skipInfo = skipped > 0 ? " (\(skipped) skipped)" : ""
+                    Logger.info("Optimized \(converted) \(ops.name) artworks\(skipInfo)")
+                }
+            }.value
+
+            try await vacuumDatabase()
+            completeBackgroundMigration(Self.artworkMigrationIdentifier)
+
+            let sizeAfter = getDatabaseSize() ?? 0
+            let spaceSaved = max(0, sizeBefore - sizeAfter)
+
+            NotificationManager.shared.stopActivity()
+            if spaceSaved > 0 {
+                let savedMB = Double(spaceSaved) / (1024.0 * 1024.0)
+                NotificationManager.shared.addMessage(.info, "Library optimized - reclaimed \(String(format: "%.1f", savedMB)) MB")
+            } else {
+                NotificationManager.shared.addMessage(.info, "Library optimized")
+            }
+            Logger.info("Artwork optimization completed")
+        } catch {
+            NotificationManager.shared.stopActivity()
+            NotificationManager.shared.addMessage(.error, "Failed to optimize library")
+            Logger.error("Artwork optimization failed: \(error)")
         }
     }
 
@@ -39,7 +276,8 @@ extension DatabaseManager {
         do {
             return try dbQueue.read { db -> Bool in
                 if try db.tableExists("background_migrations") {
-                    return try Bool.fetchOne(db,
+                    return try Bool.fetchOne(
+                        db,
                         sql: "SELECT resumable FROM background_migrations WHERE completed_at IS NULL LIMIT 1"
                     ) ?? true
                 }

--- a/Managers/Database/DMTrackProcessing.swift
+++ b/Managers/Database/DMTrackProcessing.swift
@@ -94,10 +94,10 @@ extension DatabaseManager {
                     
                     await MainActor.run {
                         // Update NotificationManager with progress
-                        NotificationManager.shared.updateScanProgress(
-                            processedFiles: globalProcessed,
-                            totalFiles: globalTotal,
-                            tracksFound: tracksFound
+                        NotificationManager.shared.updateActivityProgress(
+                            current: globalProcessed,
+                            total: globalTotal,
+                            detail: "\(globalProcessed) of \(globalTotal) files • \(tracksFound) tracks found"
                         )
                         
                         // Check threshold during initial scan

--- a/Managers/Database/DatabaseMigration.swift
+++ b/Managers/Database/DatabaseMigration.swift
@@ -133,6 +133,14 @@ struct DatabaseMigrator {
             Logger.info("v7_create_background_migrations_table migration completed")
         }
         
+        migrator.registerMigration("v8_convert_artwork_to_heic") { db in
+            try db.execute(
+                sql: "INSERT INTO background_migrations (identifier, resumable) VALUES (?, ?)",
+                arguments: ["v8_background_convert_artwork_to_heic", true]
+            )
+            Logger.info("v8_convert_artwork_to_heic: flagged for background artwork conversion")
+        }
+        
         // TODO: Uncomment in next minor release to add filename index for playlist import performance
         // migrator.registerMigration("v9_add_filename_index_for_playlist_import") { db in
         //     try db.createIndexIfNotExists(

--- a/Models/Core/Playlist.swift
+++ b/Models/Core/Playlist.swift
@@ -380,14 +380,11 @@ struct Playlist: Identifiable, FetchableRecord, PersistableRecord {
         
         collageImage.unlockFocus()
         
-        // Convert to PNG data
-        guard let tiffData = collageImage.tiffRepresentation,
-              let bitmapRep = NSBitmapImageRep(data: tiffData),
-              let pngData = bitmapRep.representation(using: .png, properties: [:]) else {
+        guard let cgImage = collageImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            Logger.warning("Failed to create CGImage from collage")
             return nil
         }
-        
-        return pngData
+        return ImageResizer.encodeHEIC(cgImage)
     }
 }
 

--- a/Utilities/ImageResizer.swift
+++ b/Utilities/ImageResizer.swift
@@ -1,6 +1,88 @@
 import AppKit
+import UniformTypeIdentifiers
 
 enum ImageResizer {
+    /// Compress image data to HEIC format, downscaling to fit within maxDimension while preserving aspect ratio.
+    /// Never upscales images smaller than maxDimension.
+    /// - Parameters:
+    ///   - imageData: Original image data in any supported format (JPEG, PNG, HEIC, etc.)
+    ///   - maxDimension: Maximum width or height in pixels (default: 960)
+    ///   - quality: HEIC compression quality (0.0 to 1.0, default: 0.8)
+    ///   - source: Optional source identifier (e.g. file path) included in failure logs
+    /// - Returns: Compressed HEIC data, or nil if compression fails
+    static func compressImage(
+        from imageData: Data,
+        maxDimension: CGFloat = 960,
+        quality: CGFloat = 0.8,
+        source: String? = nil
+    ) -> Data? {
+        guard let image = NSImage(data: imageData),
+              let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            let context = source.map { " from \($0)" } ?? ""
+            Logger.warning("Failed to create image\(context) (\(imageData.count) bytes)")
+            return nil
+        }
+
+        let srcWidth = CGFloat(cgImage.width)
+        let srcHeight = CGFloat(cgImage.height)
+
+        var destWidth = srcWidth
+        var destHeight = srcHeight
+
+        if srcWidth > maxDimension || srcHeight > maxDimension {
+            let scale = min(maxDimension / srcWidth, maxDimension / srcHeight)
+            destWidth = (srcWidth * scale).rounded(.down)
+            destHeight = (srcHeight * scale).rounded(.down)
+        }
+
+        let targetSize = NSSize(width: destWidth, height: destHeight)
+
+        guard let context = CGContext(
+            data: nil,
+            width: Int(destWidth),
+            height: Int(destHeight),
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+        ) else {
+            return resizeImage(from: imageData, to: targetSize)
+        }
+        context.interpolationQuality = .high
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: destWidth, height: destHeight))
+        guard let finalCGImage = context.makeImage() else {
+            return resizeImage(from: imageData, to: targetSize)
+        }
+
+        if let heicData = encodeHEIC(finalCGImage, quality: quality) {
+            return heicData
+        }
+
+        // Fall back to JPEG if HEIC encoding fails
+        let logContext = source.map { " from \($0)" } ?? ""
+        Logger.warning("HEIC encoding failed\(logContext), falling back to JPEG")
+        return resizeImage(from: imageData, to: targetSize)
+    }
+
+    /// Encode a CGImage as HEIC data.
+    static func encodeHEIC(_ cgImage: CGImage, quality: CGFloat = 0.8) -> Data? {
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data as CFMutableData,
+            UTType.heic.identifier as CFString,
+            1,
+            nil
+        ) else { return nil }
+        CGImageDestinationAddImage(destination, cgImage, [
+            kCGImageDestinationLossyCompressionQuality: quality
+        ] as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else {
+            Logger.warning("Failed to encode image as HEIC")
+            return nil
+        }
+        return data as Data
+    }
+
     /// Resize an image from Data to specified size and return as JPEG Data
     /// - Parameters:
     ///   - imageData: Original image data

--- a/Views/Components/Widgets/NotificationTray.swift
+++ b/Views/Components/Widgets/NotificationTray.swift
@@ -44,28 +44,20 @@ class NotificationManager: ObservableObject {
     
     @Published var isActivityInProgress = false
     @Published var activityMessage = ""
-    @Published var scanProgress: ScanProgress?
+    @Published var activityProgress: ActivityProgress?
     @Published var messages: [NotificationMessage] = []
     
     private var lastProgressUpdateTime: Date = .distantPast
     private let progressUpdateInterval: TimeInterval = 0.5
     
-    struct ScanProgress {
-        let processedFiles: Int
-        let totalFiles: Int
-        let tracksFound: Int
-        
-        var progressPercentage: Int {
-            guard totalFiles > 0 else { return 0 }
-            return Int((Double(processedFiles) / Double(totalFiles)) * 100)
-        }
-        
-        var displayText: String {
-            if totalFiles > 0 {
-                return "\(processedFiles) of \(totalFiles) files • \(tracksFound) tracks found"
-            } else {
-                return "\(tracksFound) tracks found"
-            }
+    struct ActivityProgress {
+        let current: Int
+        let total: Int
+        let detail: String?
+
+        var fraction: Double {
+            guard total > 0 else { return 0 }
+            return Double(current) / Double(total)
         }
     }
     
@@ -88,20 +80,20 @@ class NotificationManager: ObservableObject {
         DispatchQueue.main.async {
             self.isActivityInProgress = false
             self.activityMessage = ""
-            self.scanProgress = nil
+            self.activityProgress = nil
         }
     }
     
-    func updateScanProgress(processedFiles: Int, totalFiles: Int, tracksFound: Int) {
+    func updateActivityProgress(current: Int, total: Int, detail: String? = nil) {
         let now = Date()
         guard now.timeIntervalSince(lastProgressUpdateTime) >= progressUpdateInterval else { return }
         lastProgressUpdateTime = now
         
         DispatchQueue.main.async {
-            self.scanProgress = ScanProgress(
-                processedFiles: processedFiles,
-                totalFiles: totalFiles,
-                tracksFound: tracksFound
+            self.activityProgress = ActivityProgress(
+                current: current,
+                total: total,
+                detail: detail
             )
         }
     }
@@ -342,21 +334,23 @@ struct NotificationPopover: View {
                     .font(.headline)
                     .multilineTextAlignment(.center)
                 
-                if let progress = manager.scanProgress {
-                    Text(progress.displayText)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
+                if let progress = manager.activityProgress {
+                    if let detail = progress.detail {
+                        Text(detail)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
                     
-                    if progress.totalFiles > 0 {
-                        ProgressView(value: Double(progress.processedFiles), total: Double(progress.totalFiles))
+                    if progress.total > 0 {
+                        ProgressView(value: progress.fraction)
                             .progressViewStyle(.linear)
                             .frame(width: 250)
                     }
                 }
             }
             
-            if manager.scanProgress != nil {
-                Text("You can continue using the app while scanning completes")
+            if manager.activityProgress != nil {
+                Text("You can continue using the app while this completes")
                     .font(.caption)
                     .foregroundColor(.secondary.opacity(0.8))
                     .multilineTextAlignment(.center)


### PR DESCRIPTION
Uses HEIC image format to store track album art, resulting in ~50% smaller  library database. This change also adds a background migration to compress album art for existing tracks.

Fixes #215