### PR TITLE
Allow reordering sidebar items in Home and Playlists

### DIFF
--- a/Managers/Database/DMPlaylists.swift
+++ b/Managers/Database/DMPlaylists.swift
@@ -196,7 +196,7 @@ extension DatabaseManager {
         do {
             return try dbQueue.read { db in
                 // Fetch all playlists
-                var playlists = try Playlist.fetchAll(db)
+                var playlists = try Playlist.order(Playlist.Columns.sortOrder).fetchAll(db)
                 
                 // Define the result structure for counts
                 struct PlaylistCount: FetchableRecord {
@@ -247,6 +247,17 @@ extension DatabaseManager {
         }
     }
     
+    /// Update the sort order of playlists
+    func updatePlaylistsOrder(_ playlists: [Playlist]) async throws {
+        try await dbQueue.write { db in
+            for (index, playlist) in playlists.enumerated() {
+                var updated = playlist
+                updated.sortOrder = index
+                try updated.update(db)
+            }
+        }
+    }
+
     /// Load tracks for a specific playlist on demand
     func loadTracksForPlaylist(_ playlistId: UUID) -> [Track] {
         do {

--- a/Managers/Playlist/PlaylistManager.swift
+++ b/Managers/Playlist/PlaylistManager.swift
@@ -160,13 +160,30 @@ class PlaylistManager: ObservableObject {
         return playlist.tracks
     }
     
-    /// Sort playlists according to type and predefined order
+    /// Sort playlists: smart playlists first (by dateCreated), then regular playlists (by sortOrder, dateCreated as tiebreaker)
     func sortPlaylists(smart: [Playlist], regular: [Playlist]) -> [Playlist] {
-        // Combine all playlists and sort by creation date (oldest first)
-        let allPlaylists = smart + regular
-        return allPlaylists.sorted { $0.dateCreated < $1.dateCreated }
+        let sortedSmart = smart.sorted { $0.dateCreated < $1.dateCreated }
+        let sortedRegular = regular.sorted {
+            $0.sortOrder == $1.sortOrder ? $0.dateCreated < $1.dateCreated : $0.sortOrder < $1.sortOrder
+        }
+        return sortedSmart + sortedRegular
     }
-    
+
+    /// Reorder user playlists and persist the new order
+    func reorderPlaylists(_ reorderedPlaylists: [Playlist]) {
+        guard let dbManager = libraryManager?.databaseManager else { return }
+
+        playlists = reorderedPlaylists
+
+        Task {
+            do {
+                try await dbManager.updatePlaylistsOrder(reorderedPlaylists)
+            } catch {
+                Logger.error("Failed to reorder playlists: \(error)")
+            }
+        }
+    }
+
     /// Get all playlists that a track belongs to
     func getPlaylistsContainingTrack(_ track: Track) -> [Playlist] {
         playlists.filter { playlist in

--- a/Views/Components/Sidebar/SidebarListView.swift
+++ b/Views/Components/Sidebar/SidebarListView.swift
@@ -19,12 +19,21 @@ struct SidebarListView<Item: SidebarItem>: View {
     let iconColor: Color
     let showCount: Bool
 
+    // Reordering
+    let reorderableFromIndex: Int?
+    let onReorder: (([Item]) -> Void)?
+
+    // External editing trigger
+    @Binding var externalEditingItemID: UUID?
+
     @State private var hoveredItemID: UUID?
     @State private var editingItemID: UUID?
     @State private var editingText: String = ""
     @FocusState private var isEditingFieldFocused: Bool
     @State private var lastClickTime = Date()
     @State private var lastClickedItemID: UUID?
+    @State private var draggedItemID: UUID?
+    @State private var dropTargetItemID: UUID?
 
     init(
         items: [Item],
@@ -37,7 +46,10 @@ struct SidebarListView<Item: SidebarItem>: View {
         showIcon: Bool = true,
         iconColor: Color = .secondary,
         showCount: Bool = false,
-        trailingContent: ((Item) -> AnyView)? = nil
+        trailingContent: ((Item) -> AnyView)? = nil,
+        reorderableFromIndex: Int? = nil,
+        onReorder: (([Item]) -> Void)? = nil,
+        externalEditingItemID: Binding<UUID?> = .constant(nil)
     ) {
         self.items = items
         self._selectedItem = selectedItem
@@ -50,6 +62,9 @@ struct SidebarListView<Item: SidebarItem>: View {
         self.iconColor = iconColor
         self.showCount = showCount
         self.trailingContent = trailingContent
+        self.reorderableFromIndex = reorderableFromIndex
+        self.onReorder = onReorder
+        self._externalEditingItemID = externalEditingItemID
     }
 
     var body: some View {
@@ -63,16 +78,16 @@ struct SidebarListView<Item: SidebarItem>: View {
                             .foregroundColor(.secondary)
                             .textCase(.uppercase)
                     }
-                    
+
                     Spacer()
-                    
+
                     if let controls = headerControls {
                         controls
                     }
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
-                
+
                 Divider()
             }
 
@@ -83,6 +98,12 @@ struct SidebarListView<Item: SidebarItem>: View {
                 itemsList
             }
         }
+        .onChange(of: externalEditingItemID) { _, newID in
+            if let id = newID, let item = items.first(where: { $0.id == id }) {
+                startEditing(item)
+                externalEditingItemID = nil
+            }
+        }
     }
 
     // MARK: - Items List
@@ -90,7 +111,9 @@ struct SidebarListView<Item: SidebarItem>: View {
     private var itemsList: some View {
         ScrollView(.vertical) {
             LazyVStack(spacing: 1) {
-                ForEach(items) { item in
+                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                    let isDraggable = isItemDraggable(at: index)
+
                     SidebarItemRow(
                         item: item,
                         isSelected: selectedItem?.id == item.id,
@@ -117,10 +140,42 @@ struct SidebarListView<Item: SidebarItem>: View {
                             cancelEditing()
                         }
                     )
+                    .opacity(draggedItemID == item.id ? 0.4 : 1.0)
+                    .overlay(alignment: .top) {
+                        if dropTargetItemID == item.id && draggedItemID != item.id && isDraggable {
+                            Rectangle()
+                                .fill(Color.accentColor)
+                                .frame(height: 2)
+                                .padding(.horizontal, 8)
+                        }
+                    }
+                    .if(isDraggable) { view in
+                        view.onDrag {
+                            draggedItemID = item.id
+                            return NSItemProvider(object: item.id.uuidString as NSString)
+                        }
+                        .onDrop(
+                            of: [.text],
+                            delegate: SidebarReorderDropDelegate(
+                                targetItem: item,
+                                targetIndex: index,
+                                items: items,
+                                reorderableFromIndex: reorderableFromIndex ?? 0,
+                                draggedItemID: $draggedItemID,
+                                dropTargetItemID: $dropTargetItemID,
+                                onReorder: onReorder ?? { _ in }
+                            )
+                        )
+                    }
                     .contextMenu {
                         if let menuItems = contextMenuItems?(item) {
                             ForEach(Array(menuItems.enumerated()), id: \.offset) { _, menuItem in
-                                contextMenuItem(menuItem)
+                                if case .button(let title, _, _, _) = menuItem,
+                                   title == "Rename", item.isEditable, onRename != nil {
+                                    Button("Rename") { startEditing(item) }
+                                } else {
+                                    contextMenuItem(menuItem)
+                                }
                             }
                         }
                     }
@@ -145,6 +200,13 @@ struct SidebarListView<Item: SidebarItem>: View {
             .padding(.horizontal, 4)
             .padding(.vertical, 4)
         }
+    }
+
+    // MARK: - Reordering Helpers
+
+    private func isItemDraggable(at index: Int) -> Bool {
+        guard let fromIndex = reorderableFromIndex, onReorder != nil else { return false }
+        return index >= fromIndex
     }
 
     // MARK: - Empty View
@@ -200,6 +262,52 @@ struct SidebarListView<Item: SidebarItem>: View {
     }
 }
 
+// MARK: - Reorder Drop Delegate
+
+private struct SidebarReorderDropDelegate<Item: SidebarItem>: DropDelegate {
+    let targetItem: Item
+    let targetIndex: Int
+    let items: [Item]
+    let reorderableFromIndex: Int
+    @Binding var draggedItemID: UUID?
+    @Binding var dropTargetItemID: UUID?
+    let onReorder: ([Item]) -> Void
+
+    func dropEntered(info: DropInfo) {
+        guard draggedItemID != targetItem.id else { return }
+        dropTargetItemID = targetItem.id
+    }
+
+    func dropExited(info: DropInfo) {
+        if dropTargetItemID == targetItem.id {
+            dropTargetItemID = nil
+        }
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        guard let draggedID = draggedItemID else { return false }
+        guard let fromIndex = items.firstIndex(where: { $0.id == draggedID }) else { return false }
+        guard fromIndex >= reorderableFromIndex else { return false }
+        guard targetIndex >= reorderableFromIndex else { return false }
+
+        var reordered = items
+        let movedItem = reordered.remove(at: fromIndex)
+
+        let toIndex = fromIndex < targetIndex ? targetIndex - 1 : targetIndex
+        let clampedIndex = max(reorderableFromIndex, min(toIndex, reordered.count))
+        reordered.insert(movedItem, at: clampedIndex)
+
+        draggedItemID = nil
+        dropTargetItemID = nil
+        onReorder(reordered)
+        return true
+    }
+}
+
 // MARK: - Convenience Extensions
 
 extension SidebarListView where Item == LibrarySidebarItem {
@@ -220,7 +328,7 @@ extension SidebarListView where Item == LibrarySidebarItem {
 
         // Convert filter items to sidebar items
         let sidebarItems = filterItems.map { LibrarySidebarItem(filterItem: $0) }
-        
+
         // Separate unknown and regular items
         let unknownItems = sidebarItems.filter { item in
             item.filterName == filterType.unknownPlaceholder ||
@@ -230,7 +338,7 @@ extension SidebarListView where Item == LibrarySidebarItem {
             item.filterName != filterType.unknownPlaceholder &&
             item.title != filterType.unknownPlaceholder
         }
-        
+
         // Add regular items first, then unknown items at the end
         items.append(contentsOf: regularItems)
         items.append(contentsOf: unknownItems)

--- a/Views/Components/SidebarView.swift
+++ b/Views/Components/SidebarView.swift
@@ -18,7 +18,14 @@ struct SidebarView<Item: SidebarItem>: View {
     let showIcon: Bool
     let iconColor: Color
     let showCount: Bool
-    
+
+    // Reordering
+    let reorderableFromIndex: Int?
+    let onReorder: (([Item]) -> Void)?
+
+    // External editing trigger
+    @Binding var externalEditingItemID: UUID?
+
     init(
         items: [Item],
         selectedItem: Binding<Item?>,
@@ -30,7 +37,10 @@ struct SidebarView<Item: SidebarItem>: View {
         showIcon: Bool = true,
         iconColor: Color = .secondary,
         showCount: Bool = false,
-        trailingContent: ((Item) -> AnyView)? = nil
+        trailingContent: ((Item) -> AnyView)? = nil,
+        reorderableFromIndex: Int? = nil,
+        onReorder: (([Item]) -> Void)? = nil,
+        externalEditingItemID: Binding<UUID?> = .constant(nil)
     ) {
         self.items = items
         self._selectedItem = selectedItem
@@ -43,8 +53,11 @@ struct SidebarView<Item: SidebarItem>: View {
         self.iconColor = iconColor
         self.showCount = showCount
         self.trailingContent = trailingContent
+        self.reorderableFromIndex = reorderableFromIndex
+        self.onReorder = onReorder
+        self._externalEditingItemID = externalEditingItemID
     }
-    
+
     var body: some View {
         SidebarListView(
             items: items,
@@ -57,7 +70,10 @@ struct SidebarView<Item: SidebarItem>: View {
             showIcon: showIcon,
             iconColor: iconColor,
             showCount: showCount,
-            trailingContent: trailingContent
+            trailingContent: trailingContent,
+            reorderableFromIndex: reorderableFromIndex,
+            onReorder: onReorder,
+            externalEditingItemID: $externalEditingItemID
         )
     }
 }

--- a/Views/Home/HomeSidebarView.swift
+++ b/Views/Home/HomeSidebarView.swift
@@ -28,38 +28,19 @@ struct HomeSidebarView: View {
                     selectedItem = item
                 },
                 contextMenuItems: { item in
-                    if case .pinned(let pinnedItem) = item.source {
-                        return [
-                            .button(title: "Remove from Home", role: nil) {
-                                Task {
-                                    await libraryManager.removePinnedItem(pinnedItem)
-                                }
-                            }
-                        ]
-                    }
-                    return []
+                    createContextMenuItems(for: item)
                 },
                 showIcon: true,
                 iconColor: .secondary,
-                showCount: false
-            ) { item in
-                    if case .pinned(let pinnedItem) = item.source {
-                        return AnyView(
-                            Button(action: {
-                                Task {
-                                    await libraryManager.removePinnedItem(pinnedItem)
-                                }
-                            }) {
-                                Image(systemName: "pin.fill")
-                                    .font(.system(size: 11))
-                                    .foregroundColor(selectedItem?.id == item.id ? .white.opacity(0.8) : .secondary)
-                            }
-                            .buttonStyle(.plain)
-                            .help("Remove from Home")
-                        )
-                    }
-                    return AnyView(EmptyView())
-            }
+                showCount: false,
+                trailingContent: { item in
+                    trailingContentView(for: item)
+                },
+                reorderableFromIndex: HomeSidebarItem.HomeItemType.allCases.count,
+                onReorder: { reorderedItems in
+                    handlePinnedItemsReorder(reorderedItems)
+                }
+            )
         }
         .onAppear {
             updateAllItems()
@@ -163,6 +144,58 @@ struct HomeSidebarView: View {
                     }
                 }
             }
+        }
+    }
+
+    // MARK: - Context Menu & Trailing Content
+
+    private func createContextMenuItems(for item: HomeSidebarItem) -> [ContextMenuItem] {
+        if case .pinned(let pinnedItem) = item.source {
+            return [
+                .button(title: "Remove from Home", role: nil) {
+                    Task {
+                        await libraryManager.removePinnedItem(pinnedItem)
+                    }
+                }
+            ]
+        }
+        return []
+    }
+
+    private func trailingContentView(for item: HomeSidebarItem) -> AnyView {
+        if case .pinned(let pinnedItem) = item.source {
+            return AnyView(
+                Button(action: {
+                    Task {
+                        await libraryManager.removePinnedItem(pinnedItem)
+                    }
+                }) {
+                    Image(systemName: "pin.fill")
+                        .font(.system(size: 11))
+                        .foregroundColor(selectedItem?.id == item.id ? .white.opacity(0.8) : .secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Remove from Home")
+            )
+        }
+        return AnyView(EmptyView())
+    }
+
+    // MARK: - Reorder Pinned Items
+
+    private func handlePinnedItemsReorder(_ reorderedItems: [HomeSidebarItem]) {
+        let fixedCount = HomeSidebarItem.HomeItemType.allCases.count
+        let reorderedPinned = reorderedItems.dropFirst(fixedCount).compactMap { item -> PinnedItem? in
+            if case .pinned(let pinnedItem) = item.source {
+                return pinnedItem
+            }
+            return nil
+        }
+
+        allItems = reorderedItems
+
+        Task {
+            await libraryManager.reorderPinnedItems(reorderedPinned)
         }
     }
 

--- a/Views/Playlists/PlaylistSidebarView.swift
+++ b/Views/Playlists/PlaylistSidebarView.swift
@@ -7,6 +7,7 @@ struct PlaylistSidebarView: View {
     @State private var selectedSidebarItem: PlaylistSidebarItem?
     @State private var playlistToDelete: Playlist?
     @State private var showingDeleteConfirmation = false
+    @State private var editingPlaylistID: UUID?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -96,6 +97,10 @@ struct PlaylistSidebarView: View {
 
     // MARK: - Playlists List
 
+    private var nonEditableCount: Int {
+        playlistManager.playlists.prefix { !$0.isUserEditable }.count
+    }
+
     private var playlistsList: some View {
         SidebarView(
             items: allPlaylistItems,
@@ -111,12 +116,72 @@ struct PlaylistSidebarView: View {
             },
             showIcon: true,
             iconColor: .secondary,
-            showCount: false
+            showCount: false,
+            trailingContent: { item in
+                kebabMenu(for: item)
+            },
+            reorderableFromIndex: nonEditableCount,
+            onReorder: { reorderedItems in
+                handlePlaylistReorder(reorderedItems)
+            },
+            externalEditingItemID: $editingPlaylistID
+        )
+    }
+
+    // MARK: - Kebab Menu
+
+    private func kebabMenu(for item: PlaylistSidebarItem) -> AnyView {
+        guard item.playlist.isUserEditable else { return AnyView(EmptyView()) }
+
+        let isSelected = selectedSidebarItem?.id == item.id
+        let isPinned = playlistManager.isPlaylistPinned(item.playlist)
+
+        return AnyView(
+            Menu {
+                Button(isPinned ? "Remove from Home" : "Pin to Home") {
+                    Task {
+                        if isPinned {
+                            await playlistManager.unpinPlaylist(item.playlist)
+                        } else {
+                            await playlistManager.pinPlaylist(item.playlist)
+                        }
+                    }
+                }
+
+                Divider()
+
+                Button("Rename") {
+                    editingPlaylistID = item.id
+                }
+
+                Divider()
+
+                Button("Delete", role: .destructive) {
+                    playlistToDelete = item.playlist
+                    showingDeleteConfirmation = true
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 11))
+                    .foregroundColor(isSelected ? .white.opacity(0.8) : .secondary)
+                    .imageScale(.large)
+                    .frame(width: 16, height: 16)
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
         )
     }
 
     private var allPlaylistItems: [PlaylistSidebarItem] {
         playlistManager.playlists.map { PlaylistSidebarItem(playlist: $0) }
+    }
+
+    // MARK: - Reorder Playlists
+
+    private func handlePlaylistReorder(_ reorderedItems: [PlaylistSidebarItem]) {
+        let reorderedPlaylists = reorderedItems.map { $0.playlist }
+        playlistManager.reorderPlaylists(reorderedPlaylists)
     }
 
     // MARK: - Context Menu


### PR DESCRIPTION
Pinned items in Home sidebar and user playlists in Playlist sidebar can now be reordered using drag and drop.


https://github.com/user-attachments/assets/9d1c45c9-f8ab-4616-9bfe-09778b21cfd2

