### PR TITLE
Follow-up fixes around pinned items and artist info fetching

### DIFF
--- a/Managers/ArtistBioManager.swift
+++ b/Managers/ArtistBioManager.swift
@@ -134,6 +134,12 @@ class ArtistBioManager {
                     databaseManager.markArtistImageFetchFailed(artistId: artist.id)
                 }
 
+                // Stamp bioUpdatedAt when a bio fetch was attempted but returned nil,
+                // so we don't re-query the same artist on every run.
+                if !artist.hasBio && bio == nil {
+                    databaseManager.markArtistBioFetchFailed(artistId: artist.id)
+                }
+
                 // Flush pending UI updates every 2 seconds
                 if !pendingUpdates.isEmpty && Date().timeIntervalSince(lastUIUpdate) >= uiUpdateInterval {
                     await self.flushUIUpdates(pendingUpdates, using: libraryManager)

--- a/Managers/Database/DMMetadata.swift
+++ b/Managers/Database/DMMetadata.swift
@@ -345,6 +345,22 @@ extension DatabaseManager {
         }
     }
 
+    func markArtistBioFetchFailed(artistId: Int64) {
+        do {
+            _ = try dbQueue.write { db in
+                try Artist
+                    .filter(Artist.Columns.id == artistId)
+                    .updateAll(
+                        db,
+                        Artist.Columns.bioUpdatedAt.set(to: Date()),
+                        Artist.Columns.updatedAt.set(to: Date())
+                    )
+            }
+        } catch {
+            Logger.error("Failed to mark artist bio fetch failed for ID \(artistId): \(error)")
+        }
+    }
+
     struct ArtistFetchInfo {
         let id: Int64
         let name: String
@@ -361,7 +377,10 @@ extension DatabaseManager {
                     Artist.Columns.imageUpdatedAt == nil ||
                     Artist.Columns.imageUpdatedAt < sevenDaysAgo.databaseValue
                 )
-                let needsBio = Artist.Columns.bio == nil
+                let needsBio = Artist.Columns.bio == nil && (
+                    Artist.Columns.bioUpdatedAt == nil ||
+                    Artist.Columns.bioUpdatedAt < sevenDaysAgo.databaseValue
+                )
 
                 let rows = try Artist
                     .select(

--- a/Views/Home/EntityDetailView.swift
+++ b/Views/Home/EntityDetailView.swift
@@ -533,6 +533,8 @@ struct EntityDetailView: View {
         // Load artist bio for person entities (artists, album artists, composers)
         if entity is ArtistEntity {
             artistBio = libraryManager.databaseManager.getArtistBio(for: entity.name)
+        } else {
+            artistBio = nil
         }
 
         self.isLoading = false


### PR DESCRIPTION
Fixes following bugs that were introduced with new features added in this release;

- Pinned artist bio is cached and leaks into other pinned items
- Artist bio is continuously attempted to fetch even if it results in no response.