### PR TITLE
Fix album art appearing blurry in Albums & Artists view

### DIFF
--- a/Managers/PlaybackManager.swift
+++ b/Managers/PlaybackManager.swift
@@ -98,7 +98,7 @@ class PlaybackManager: NSObject, ObservableObject {
         tempTrack.title = uiState.trackTitle
         tempTrack.artist = uiState.trackArtist
         tempTrack.album = uiState.trackAlbum
-        tempTrack.albumArtworkMedium = uiState.artworkData
+        tempTrack.albumArtworkData = uiState.artworkData
         tempTrack.duration = uiState.trackDuration
         tempTrack.isMetadataLoaded = true
         

--- a/Models/Core/Entity.swift
+++ b/Models/Core/Entity.swift
@@ -21,23 +21,11 @@ protocol Entity: Identifiable {
     var subtitle: String? { get }
     var trackCount: Int { get }
     var artworkData: Data? { get }
-    var artworkMedium: Data? { get }
-    var artworkLarge: Data? { get }
 }
 
-// MARK: - Shared Artwork & Color Defaults
-
-private var sharedArtworkCache = NSCache<NSString, NSData>()
+// MARK: - Shared Color Defaults
 
 extension Entity {
-    var artworkMedium: Data? {
-        cachedResizedArtwork(suffix: "medium", size: ImageUtils.Size.medium)
-    }
-
-    var artworkLarge: Data? {
-        cachedResizedArtwork(suffix: "large", size: ImageUtils.Size.large)
-    }
-
     var dominantColors: [NSColor] {
         guard let original = artworkData else { return [] }
         return ImageUtils.cachedDominantColors(id: id, imageData: original)
@@ -46,21 +34,6 @@ extension Entity {
     func backgroundGradientColors(isDark: Bool) -> [Color] {
         guard let original = artworkData else { return [] }
         return ImageUtils.cachedBackgroundGradientColors(id: id, imageData: original, isDark: isDark)
-    }
-
-    private func cachedResizedArtwork(suffix: String, size: NSSize) -> Data? {
-        guard let original = artworkData else { return nil }
-
-        let cacheKey = "\(id.uuidString)-\(suffix)" as NSString
-        if let cached = sharedArtworkCache.object(forKey: cacheKey) {
-            return cached as Data
-        }
-
-        if let jpegData = ImageUtils.resizeImage(from: original, to: size) {
-            sharedArtworkCache.setObject(jpegData as NSData, forKey: cacheKey)
-            return jpegData
-        }
-        return nil
     }
 }
 

--- a/Models/Core/Track.swift
+++ b/Models/Core/Track.swift
@@ -44,81 +44,11 @@ struct Track: Identifiable, Equatable, Hashable, FetchableRecord, PersistableRec
     
     // Transient properties for album artwork (populated separately)
     var albumArtworkData: Data?
-    private static var artworkCache = NSCache<NSString, NSData>()
-    
+
     var filename: String {
         url.lastPathComponent
     }
-    
-    var albumArtworkSmall: Data? {
-        get {
-            guard let original = albumArtworkData else { return nil }
-            
-            let cacheKey = "\(trackId?.description ?? url.path)-small" as NSString
-            if let cached = Track.artworkCache.object(forKey: cacheKey) {
-                return cached as Data
-            }
-            
-            if let jpegData = ImageUtils.resizeImage(from: original, to: ImageUtils.Size.small) {
-                Track.artworkCache.setObject(jpegData as NSData, forKey: cacheKey)
-                return jpegData
-            }
-            return nil
-        }
-        set {
-            let cacheKey = "\(trackId?.description ?? url.path)-small" as NSString
-            if let data = newValue {
-                Track.artworkCache.setObject(data as NSData, forKey: cacheKey)
-            }
-        }
-    }
 
-    var albumArtworkMedium: Data? {
-        get {
-            guard let original = albumArtworkData else { return nil }
-            
-            let cacheKey = "\(trackId?.description ?? url.path)-medium" as NSString
-            if let cached = Track.artworkCache.object(forKey: cacheKey) {
-                return cached as Data
-            }
-            
-            if let jpegData = ImageUtils.resizeImage(from: original, to: ImageUtils.Size.medium) {
-                Track.artworkCache.setObject(jpegData as NSData, forKey: cacheKey)
-                return jpegData
-            }
-            return nil
-        }
-        set {
-            let cacheKey = "\(trackId?.description ?? url.path)-medium" as NSString
-            if let data = newValue {
-                Track.artworkCache.setObject(data as NSData, forKey: cacheKey)
-            }
-        }
-    }
-
-    var albumArtworkLarge: Data? {
-        get {
-            guard let original = albumArtworkData else { return nil }
-            
-            let cacheKey = "\(trackId?.description ?? url.path)-large" as NSString
-            if let cached = Track.artworkCache.object(forKey: cacheKey) {
-                return cached as Data
-            }
-            
-            if let jpegData = ImageUtils.resizeImage(from: original, to: ImageUtils.Size.large) {
-                Track.artworkCache.setObject(jpegData as NSData, forKey: cacheKey)
-                return jpegData
-            }
-            return nil
-        }
-        set {
-            let cacheKey = "\(trackId?.description ?? url.path)-large" as NSString
-            if let data = newValue {
-                Track.artworkCache.setObject(data as NSData, forKey: cacheKey)
-            }
-        }
-    }
-    
     var dominantColors: [NSColor] {
         guard let original = albumArtworkData else { return [] }
         return ImageUtils.cachedDominantColors(id: id, imageData: original)

--- a/Utilities/ImageUtils.swift
+++ b/Utilities/ImageUtils.swift
@@ -391,13 +391,6 @@ enum ImageUtils {
         guard let cgImage = ctx.makeImage() else { return nil }
         return NSBitmapImageRep(cgImage: cgImage).representation(using: .jpeg, properties: [.compressionFactor: 0.85])
     }
-
-    /// Common sizes used in the app
-    enum Size {
-        static let small = NSSize(width: ViewDefaults.tableArtworkSize * 2, height: ViewDefaults.tableArtworkSize * 2)    // Table view (2x retina)
-        static let medium = NSSize(width: ViewDefaults.listArtworkSize * 2, height: ViewDefaults.listArtworkSize * 2)     // List view (2x retina)
-        static let large = NSSize(width: ViewDefaults.gridArtworkSize * 2, height: ViewDefaults.gridArtworkSize * 2)      // Grid view (2x retina)
-    }
 }
 
 // MARK: - Color Cache Object

--- a/Views/Components/EntityGridView.swift
+++ b/Views/Components/EntityGridView.swift
@@ -141,7 +141,6 @@ private class RenderedImageCache {
             return cached
         }
 
-        // Use original artworkData (not artworkLarge) to preserve aspect ratio
         guard let artworkData = entity.artworkData else { return nil }
 
         let renderedImage = createRenderedImage(from: artworkData)
@@ -154,14 +153,15 @@ private class RenderedImageCache {
     }
     
     private func createRenderedImage(from data: Data) -> NSImage? {
-        guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil),
-              let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, [
-                kCGImageSourceShouldCacheImmediately: true
-              ] as CFDictionary) else {
+        guard let nsImage = NSImage(data: data),
+              let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
             return nil
         }
 
-        let targetSize = Int(ViewDefaults.gridArtworkSize)
+        // Rasterize at 2x to provide enough pixels for Retina displays
+        let pointSize = ViewDefaults.gridArtworkSize
+        let scale: CGFloat = 2
+        let pixelSize = Int(pointSize * scale)
         let srcWidth = cgImage.width
         let srcHeight = cgImage.height
 
@@ -180,16 +180,16 @@ private class RenderedImageCache {
         // Draw into a square context with rounded corners via clipping path
         guard let context = CGContext(
             data: nil,
-            width: targetSize,
-            height: targetSize,
+            width: pixelSize,
+            height: pixelSize,
             bitsPerComponent: 8,
             bytesPerRow: 0,
             space: CGColorSpaceCreateDeviceRGB(),
             bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
         ) else { return nil }
 
-        let drawRect = CGRect(x: 0, y: 0, width: targetSize, height: targetSize)
-        let cornerRadius: CGFloat = 8
+        let drawRect = CGRect(x: 0, y: 0, width: pixelSize, height: pixelSize)
+        let cornerRadius: CGFloat = 8 * scale
         let path = CGPath(roundedRect: drawRect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
         context.addPath(path)
         context.clip()
@@ -197,7 +197,7 @@ private class RenderedImageCache {
         context.draw(croppedCG, in: drawRect)
 
         guard let finalCG = context.makeImage() else { return nil }
-        return NSImage(cgImage: finalCG, size: NSSize(width: targetSize, height: targetSize))
+        return NSImage(cgImage: finalCG, size: NSSize(width: pointSize, height: pointSize))
     }
 }
 
@@ -217,6 +217,8 @@ private struct EntityGridItem<T: Entity>: View {
             Group {
                 if let image = renderedImage {
                     Image(nsImage: image)
+                        .resizable()
+                        .interpolation(.high)
                         .frame(width: ViewDefaults.gridArtworkSize, height: ViewDefaults.gridArtworkSize)
                         .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 5)
                 } else {


### PR DESCRIPTION
Fixes a bug where wrong density album artwork or image was being used in entity grid, causing images to appear blurry in Albums and Artists views, also cleans up unused image cache.

Fixes #254

|Before|After|
|---|---|
|<img width="395" height="577" alt="image" src="https://github.com/user-attachments/assets/b3b10254-f472-4623-8753-e6f526f3740d" />|<img width="383" height="583" alt="image" src="https://github.com/user-attachments/assets/301aa9de-4585-4bbc-abaa-25bf2ace3151" />|
