### PR TITLE
Fix tracks not showing correctly on item select in Library tab

### DIFF
--- a/Views/Components/TrackViews/TrackTableView.swift
+++ b/Views/Components/TrackViews/TrackTableView.swift
@@ -391,7 +391,7 @@ struct TrackTableView: View {
             return
         }
 
-        let initialTracks = (sortedTracks.count != tracks.count) ? tracks : sortedTracks
+        let initialTracks = tracks
 
         Task.detached(priority: .userInitiated) {
             let sorted = initialTracks.sorted(using: newSortOrder)


### PR DESCRIPTION
Fixes a bug where selecting a sidebar item in the Library tab would not show the corresponding tracks list in certain cases.