### PR TITLE
Prevent high-res track album art from causing memory overload

### DIFF
--- a/Core/MetadataExtractor.swift
+++ b/Core/MetadataExtractor.swift
@@ -573,13 +573,21 @@ class MetadataExtractor {
 
         let rawData = firstPicture.imageData
 
+        if rawData.count > AlbumArtFormat.maxArtworkSize {
+            let context = source.map { " for \($0)" } ?? ""
+            Logger.warning("Skipping oversized embedded artwork\(context) (\(rawData.count) bytes)")
+            return
+        }
+
         // Check cache for previously compressed identical artwork
         if let cache = artworkCache, let cached = await cache.get(for: rawData) {
             metadata.artworkData = cached
             return
         }
 
-        let compressed = ImageUtils.compressImage(from: rawData, source: source) ?? rawData
+        // If compression fails, leave artworkData nil rather than persisting undecodable bytes
+        // that would re-fail on every later read (sidebar, now-playing, color extraction).
+        guard let compressed = ImageUtils.compressImage(from: rawData, source: source) else { return }
         metadata.artworkData = compressed
 
         // Store in cache for subsequent tracks with identical artwork

--- a/Utilities/Constants.swift
+++ b/Utilities/Constants.swift
@@ -149,6 +149,7 @@ enum AlbumArtFormat {
     static let priorityKeywords = ["cover", "folder", "album", "artwork", "front"]
 
     static let maxArtworkSize: Int = 20 * 1024 * 1024
+    static let maxArtworkPixelDimension: Int = 8000
 
     static func isSupported(_ fileExtension: String) -> Bool {
         supportedExtensions.contains(fileExtension.lowercased())

--- a/Utilities/ImageUtils.swift
+++ b/Utilities/ImageUtils.swift
@@ -22,14 +22,26 @@ enum ImageUtils {
         return compressImageIntel(from: imageData, maxDimension: maxDimension, quality: quality, source: source)
         #else
         guard let imageSource = CGImageSourceCreateWithData(imageData as CFData, nil),
-              let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+              let props = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [CFString: Any],
+              let srcWidth = props[kCGImagePropertyPixelWidth] as? CGFloat,
+              let srcHeight = props[kCGImagePropertyPixelHeight] as? CGFloat else {
             let context = source.map { " from \($0)" } ?? ""
-            Logger.warning("Failed to create image\(context) (\(imageData.count) bytes)")
+            Logger.warning("Failed to read image properties\(context) (\(imageData.count) bytes)")
             return nil
         }
 
-        let srcWidth = CGFloat(cgImage.width)
-        let srcHeight = CGFloat(cgImage.height)
+        let pixelLimit = CGFloat(AlbumArtFormat.maxArtworkPixelDimension)
+        if srcWidth > pixelLimit || srcHeight > pixelLimit {
+            let context = source.map { " from \($0)" } ?? ""
+            Logger.warning("Skipping oversized artwork \(Int(srcWidth))x\(Int(srcHeight))\(context)")
+            return nil
+        }
+
+        guard let cgImage = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+            let context = source.map { " from \($0)" } ?? ""
+            Logger.warning("Failed to decode image\(context) (\(imageData.count) bytes)")
+            return nil
+        }
 
         var destWidth = srcWidth
         var destHeight = srcHeight
@@ -431,6 +443,13 @@ enum ImageUtils {
               let height = props[kCGImagePropertyPixelHeight] as? CGFloat else {
             let context = source.map { " from \($0)" } ?? ""
             Logger.warning("Failed to read image properties\(context) (\(imageData.count) bytes)")
+            return nil
+        }
+
+        let pixelLimit = CGFloat(AlbumArtFormat.maxArtworkPixelDimension)
+        if width > pixelLimit || height > pixelLimit {
+            let context = source.map { " from \($0)" } ?? ""
+            Logger.warning("Skipping oversized artwork \(Int(width))x\(Int(height))\(context)")
             return nil
         }
 


### PR DESCRIPTION
Guards artwork extraction and resize logic from loading very high-res album artwork that can potentially cause memory overload and crash. This is follow up to fix made in #268.

Fixes #273