### PR TITLE
Prevent potential hang risk while viewing a playlist

### DIFF
--- a/Models/Core/Playlist.swift
+++ b/Models/Core/Playlist.swift
@@ -280,20 +280,28 @@ struct Playlist: Identifiable, FetchableRecord, PersistableRecord {
         if let customCover = coverArtworkData {
             return customCover
         }
-
         let selected = collageTracks()
         let selectedIDs = selected.map { $0.id }
+        return PlaylistArtworkCache.shared.getCachedArtwork(for: id, currentTrackIDs: selectedIDs)
+    }
 
+    func warmArtworkCacheIfNeeded() async -> Data? {
+        if let customCover = coverArtworkData {
+            return customCover
+        }
+        let selected = collageTracks()
+        let selectedIDs = selected.map { $0.id }
         if let cached = PlaylistArtworkCache.shared.getCachedArtwork(for: id, currentTrackIDs: selectedIDs) {
             return cached
         }
-
-        if let collage = generateCollageArtwork(from: selected) {
-            PlaylistArtworkCache.shared.setCachedArtwork(collage, for: id, trackIDs: selectedIDs)
-            return collage
+        let playlistID = id
+        let collage = await Task.detached(priority: .utility) {
+            Self.renderCollageArtwork(from: selected)
+        }.value
+        if let collage {
+            PlaylistArtworkCache.shared.setCachedArtwork(collage, for: playlistID, trackIDs: selectedIDs)
         }
-
-        return nil
+        return collage
     }
 
     // Get the effective track limit for display
@@ -321,8 +329,7 @@ struct Playlist: Identifiable, FetchableRecord, PersistableRecord {
         return result
     }
 
-    /// Renders a collage image from the given tracks into a 256×256 HEIC.
-    private func generateCollageArtwork(from collageTracks: [Track]) -> Data? {
+    fileprivate static func renderCollageArtwork(from collageTracks: [Track]) -> Data? {
         guard !collageTracks.isEmpty else { return nil }
 
         let pixelSize = 256
@@ -374,7 +381,14 @@ struct Playlist: Identifiable, FetchableRecord, PersistableRecord {
             Logger.warning("Failed to create CGImage from collage context")
             return nil
         }
+
+        // Software HEVC encode deadlocks under concurrent invocation on Intel (issue #265),
+        // so mirror the JPEG fallback used by ImageUtils.compressImage.
+        #if arch(x86_64)
+        return ImageUtils.encodeJPEG(collageImage)
+        #else
         return ImageUtils.encodeHEIC(collageImage)
+        #endif
     }
 }
 

--- a/Views/Components/ArtistImageSheet.swift
+++ b/Views/Components/ArtistImageSheet.swift
@@ -171,12 +171,17 @@ struct ArtistImageSheet: View {
             Button("Save") {
                 guard let index = selectedIndex, index < images.count else { return }
                 let result = images[index]
-
-                if let compressed = ImageUtils.compressImage(from: result.imageData, source: "ArtistImageSheet/\(result.source)") {
-                    let source = result.source.components(separatedBy: " – ").first ?? result.source
-                    saveArtistImage(compressed, url: result.imageUrl, source: source)
-                }
                 isPresented = false
+                Task(priority: .utility) {
+                    guard let compressed = ImageUtils.compressImage(
+                        from: result.imageData,
+                        source: "ArtistImageSheet/\(result.source)"
+                    ) else { return }
+                    let source = result.source.components(separatedBy: " – ").first ?? result.source
+                    await MainActor.run {
+                        saveArtistImage(compressed, url: result.imageUrl, source: source)
+                    }
+                }
             }
             .buttonStyle(.borderedProminent)
             .disabled(selectedIndex == nil)

--- a/Views/Playlists/PlaylistDetailView.swift
+++ b/Views/Playlists/PlaylistDetailView.swift
@@ -9,6 +9,7 @@ struct PlaylistDetailView: View {
     @State private var showingReorderTracks = false
     @State private var isCustomSort = false
     @State private var gradientColors: [Color] = []
+    @State private var artworkData: Data?
 
     @AppStorage("useArtworkColors")
     private var useArtworkColors = true
@@ -50,26 +51,24 @@ struct PlaylistDetailView: View {
             .sheet(isPresented: $showingReorderTracks) {
                 ReorderTracksSheet(playlist: playlist)
             }
+            .task(id: playlistArtworkTaskID) {
+                artworkData = await playlist.warmArtworkCacheIfNeeded()
+                updateGradientColors()
+            }
             .onChange(of: playlistID) {
                 selectedTrackID = nil
                 loadSortPreference()
             }
             .onChange(of: playlist.dateModified) {
                 loadPlaylistTracksIfNeeded()
-                updateGradientColors()
             }
             .onAppear {
                 loadPlaylistTracksIfNeeded()
-                updateGradientColors()
                 loadSortPreference()
             }
             .onChange(of: playlist.id) {
                 loadPlaylistTracksIfNeeded()
-                updateGradientColors()
                 loadSortPreference()
-            }
-            .onChange(of: playlist.tracks.count) {
-                updateGradientColors()
             }
             .onReceive(NotificationCenter.default.publisher(for: .trackTableSortChanged)) { notification in
                 if let customSort = notification.userInfo?["isCustomSort"] as? Bool {
@@ -138,7 +137,7 @@ struct PlaylistDetailView: View {
 
     private var playlistArtwork: some View {
         Group {
-            if let artworkData = playlist?.artworkData,
+            if let artworkData,
                let nsImage = NSImage(data: artworkData) {
                 Image(nsImage: nsImage)
                     .resizable()
@@ -377,7 +376,7 @@ struct PlaylistDetailView: View {
     private func updateGradientColors() {
         guard useArtworkColors,
               let playlist = playlist,
-              let artworkData = playlist.artworkData else {
+              let artworkData = artworkData else {
             gradientColors = []
             return
         }
@@ -386,6 +385,11 @@ struct PlaylistDetailView: View {
             imageData: artworkData,
             isDark: colorScheme == .dark
         )
+    }
+
+    private var playlistArtworkTaskID: String {
+        guard let playlist else { return "nil" }
+        return "\(playlist.id)-\(playlist.dateModified.timeIntervalSince1970)-\(playlist.tracks.count)"
     }
 
     private func loadSortPreference() {


### PR DESCRIPTION
Fixes a bug where viewing a playlist causes app to hang in case artwork collage is stalled during render. This is also a follow-up to #268 for a fix towards Intel macs.