### PR TITLE
Fix blank title/artist/album for tracks with empty string metadata tags

### DIFF
--- a/Managers/Database/DMMetadata.swift
+++ b/Managers/Database/DMMetadata.swift
@@ -11,12 +11,12 @@ import GRDB
 extension DatabaseManager {
     func applyMetadataToTrack(_ track: inout FullTrack, from metadata: TrackMetadata, at fileURL: URL) {
         // Core fields
-        track.title = metadata.title ?? fileURL.deletingPathExtension().lastPathComponent
-        track.artist = metadata.artist ?? "Unknown Artist"
-        track.album = metadata.album ?? "Unknown Album"
-        track.genre = metadata.genre ?? "Unknown Genre"
-        track.composer = metadata.composer ?? "Unknown Composer"
-        track.year = metadata.year ?? ""
+        track.title = metadata.title?.nilIfEmpty ?? fileURL.deletingPathExtension().lastPathComponent
+        track.artist = metadata.artist?.nilIfEmpty ?? "Unknown Artist"
+        track.album = metadata.album?.nilIfEmpty ?? "Unknown Album"
+        track.genre = metadata.genre?.nilIfEmpty ?? "Unknown Genre"
+        track.composer = metadata.composer?.nilIfEmpty ?? "Unknown Composer"
+        track.year = metadata.year?.nilIfEmpty ?? ""
         track.duration = metadata.duration
         
         // Avoid storing album art in track table for tracks with albums

--- a/Managers/Database/DatabaseManager.swift
+++ b/Managers/Database/DatabaseManager.swift
@@ -189,3 +189,9 @@ extension Array where Element: Hashable {
         }
     }
 }
+
+// MARK: - String Extension
+
+extension String {
+    var nilIfEmpty: String? { trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self }
+}


### PR DESCRIPTION
Files with empty string tags (rather than absent tags) were stored as-is in the database, causing blank display. Treat empty strings the same as nil so the filename/Unknown Artist/Unknown Album fallbacks apply.

<img width="2620" height="1720" alt="Screenshot 2026-05-09 at 18-24-32" src="https://github.com/user-attachments/assets/d8e0c920-c2cb-46f4-b551-29ca5891f66f" />

<img width="1200" height="800" alt="Screenshot 2026-05-09 at 18-25-23" src="https://github.com/user-attachments/assets/b79e3efe-8793-4397-bbf0-e81eb332d8d1" />
