### PR TITLE
Add Spatialize Stereo support with head tracking

### DIFF
--- a/Configuration/Info.plist
+++ b/Configuration/Info.plist
@@ -48,6 +48,8 @@
     <true/>
     <key>NSSupportsAutomaticGraphicsSwitching</key>
     <true/>
+    <key>NSMotionUsageDescription</key>
+    <string>Petrichor uses headphone motion data to provide head-tracked spatial audio.</string>
     
     <!-- Sparkle Configuration -->
     <key>SUPublicEDKey</key>

--- a/Core/AudioPlayer.swift
+++ b/Core/AudioPlayer.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreMotion
 import Foundation
 import SFBAudioEngine
 
@@ -156,6 +157,12 @@ public class PAudioPlayer: NSObject {
     private var userPreampGain: Float = 0.0
     private var currentEQGains: [Float] = Array(repeating: 0.0, count: 10)
     private let eqFrequencies: [Float] = [32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
+
+    /// Spatial Audio (Spatialize Stereo)
+    private var spatialAudioEnabled: Bool = false
+    private var headTrackingEnabled: Bool = false
+    private var environmentNode: AVAudioEnvironmentNode?
+    private var headphoneMotionManager: CMHeadphoneMotionManager?
     
     // MARK: - Initialization
     
@@ -169,6 +176,7 @@ public class PAudioPlayer: NSObject {
     }
     
     deinit {
+        headphoneMotionManager?.stopDeviceMotionUpdates()
         sfbPlayer.stop()
     }
     
@@ -374,7 +382,46 @@ public class PAudioPlayer: NSObject {
     public func isStereoWideningEnabled() -> Bool {
         return stereoWideningEnabled
     }
-    
+
+    // MARK: - Spatial Audio
+
+    /// Enable or disable Spatialize Stereo (spatial audio rendering)
+    /// - Parameter enabled: boolean for the current state of spatial audio
+    public func setSpatialAudio(enabled: Bool) {
+        spatialAudioEnabled = enabled
+
+        if !effectsAttached {
+            setupAudioEffects()
+        }
+
+        applySpatialSourceMode()
+        updateHeadTrackingState()
+
+        Logger.info("Spatialize Stereo \(enabled ? "enabled" : "disabled")")
+    }
+
+    /// Check if spatial audio is currently enabled
+    /// - Returns: true if Spatialize Stereo is enabled, false otherwise
+    public func isSpatialAudioEnabled() -> Bool {
+        return spatialAudioEnabled
+    }
+
+    /// Enable or disable head tracking for spatial audio
+    /// - Parameter enabled: boolean for the current state of head tracking
+    /// - Note: Head tracking only takes effect while spatial audio is enabled, and
+    ///   requires headphones that provide motion data (e.g. AirPods Pro / AirPods Max)
+    public func setHeadTracking(enabled: Bool) {
+        headTrackingEnabled = enabled
+        updateHeadTrackingState()
+        Logger.info("Head tracking \(enabled ? "enabled" : "disabled")")
+    }
+
+    /// Check if head tracking is currently enabled
+    /// - Returns: true if head tracking is enabled, false otherwise
+    public func isHeadTrackingEnabled() -> Bool {
+        return headTrackingEnabled
+    }
+
     /// Enable or disable the equalizer
     /// - Parameter enabled: boolean for the current state Equalizer
     public func setEQEnabled(_ enabled: Bool) {
@@ -519,30 +566,44 @@ public class PAudioPlayer: NSObject {
         }
         
         // Detach and recreate effect nodes with the new format
+        if let oldEnvironmentNode = environmentNode {
+            engine.detach(oldEnvironmentNode)
+            environmentNode = nil
+        }
+
         if let oldStereoNode = stereoWideningNode {
             engine.detach(oldStereoNode)
             stereoWideningNode = nil
         }
-        
+
         if let oldEQNode = eqNode {
             engine.detach(oldEQNode)
             eqNode = nil
         }
-        
+
         // Recreate the effects chain
+        setupSpatialAudio(engine: engine)
         setupStereoWidening(engine: engine)
         setupEqualizer(engine: engine)
-        
+
         let mainMixer = engine.mainMixerNode
-        
-        if let stereoNode = stereoWideningNode, let equalizer = eqNode {
-            engine.connect(stereoNode, to: equalizer, format: format)
-            engine.connect(equalizer, to: mainMixer, format: format)
-            Logger.info("Reconfigured audio graph: playerNode -> stereoWidening -> EQ -> mainMixer")
-            
-            return stereoNode
+
+        if let environment = environmentNode, let stereoNode = stereoWideningNode, let equalizer = eqNode {
+            let chainFormat = spatialChainFormat(for: format)
+            engine.connect(environment, to: stereoNode, format: chainFormat)
+            engine.connect(stereoNode, to: equalizer, format: chainFormat)
+            engine.connect(equalizer, to: mainMixer, format: chainFormat)
+            Logger.info("Reconfigured audio graph: playerNode -> spatialAudio -> stereoWidening -> EQ -> mainMixer")
+
+            // SFBAudioEngine connects sourceNode to the returned node; the source mode is
+            // re-applied async since the new mixing destination doesn't exist yet
+            DispatchQueue.main.async { [weak self] in
+                self?.applySpatialSourceMode()
+            }
+
+            return environment
         }
-        
+
         Logger.warning("Failed to reconfigure effects chain, falling back to mixer")
         return mainMixer
     }
@@ -607,25 +668,121 @@ public class PAudioPlayer: NSObject {
         Logger.info("Source node: \(sourceNode), Format: \(format.sampleRate)Hz, \(format.channelCount)ch")
         
         sfbPlayer.modifyProcessingGraph { [self] engine in
+            setupSpatialAudio(engine: engine)
             setupStereoWidening(engine: engine)
             setupEqualizer(engine: engine)
-            
-            guard let stereoNode = stereoWideningNode, let equalizer = eqNode else {
+
+            guard let environment = environmentNode,
+                  let stereoNode = stereoWideningNode,
+                  let equalizer = eqNode else {
                 Logger.warning("Failed to create effect nodes")
                 return
             }
-            
+
+            // The environment node renders to stereo regardless of the source channel count
+            let chainFormat = spatialChainFormat(for: format)
+
             // Disconnect sourceNode from mainMixer
             engine.disconnectNodeOutput(sourceNode)
-            
-            // Connect: sourceNode -> stereoWidening -> EQ -> mainMixer
-            engine.connect(sourceNode, to: stereoNode, format: format)
-            engine.connect(stereoNode, to: equalizer, format: format)
-            engine.connect(equalizer, to: mainMixer, format: format)
-            
+
+            // Connect: sourceNode -> spatialAudio -> stereoWidening -> EQ -> mainMixer
+            engine.connect(sourceNode, to: environment, format: format)
+            engine.connect(environment, to: stereoNode, format: chainFormat)
+            engine.connect(stereoNode, to: equalizer, format: chainFormat)
+            engine.connect(equalizer, to: mainMixer, format: chainFormat)
+
+            // Apply the source mode after connecting so the mixing destination exists
+            applySpatialSourceMode()
+
             effectsAttached = true
             Logger.info("Audio effects setup complete")
         }
+    }
+
+    private func setupSpatialAudio(engine: AVAudioEngine) {
+        let environment = AVAudioEnvironmentNode()
+        // Spatialize Stereo is a headphones feature; .headphones selects binaural rendering
+        environment.outputType = .headphones
+        environment.listenerPosition = AVAudio3DPoint(x: 0, y: 0, z: 0)
+        environment.listenerAngularOrientation = AVAudio3DAngularOrientation(yaw: 0, pitch: 0, roll: 0)
+
+        engine.attach(environment)
+        self.environmentNode = environment
+
+        Logger.info("Attached environment node (Spatialize Stereo)")
+    }
+
+    /// Stereo output format matching the source sample rate, used downstream of the environment node
+    private func spatialChainFormat(for format: AVAudioFormat) -> AVAudioFormat {
+        AVAudioFormat(standardFormatWithSampleRate: format.sampleRate, channels: 2) ?? format
+    }
+
+    /// Applies the spatialization mode to the player's source node feeding the environment node
+    private func applySpatialSourceMode() {
+        let sourceNode = sfbPlayer.sourceNode
+        // .auto picks the highest-quality binaural algorithm for the configured output type
+        sourceNode.renderingAlgorithm = .auto
+        // .ambienceBed spatializes the stereo channels as far-field sources anchored to
+        // global space (i.e. "Spatialize Stereo"); .bypass passes audio through untouched
+        sourceNode.sourceMode = spatialAudioEnabled ? .ambienceBed : .bypass
+    }
+
+    // MARK: - Head Tracking
+
+    private func updateHeadTrackingState() {
+        if spatialAudioEnabled && headTrackingEnabled {
+            startHeadTracking()
+        } else {
+            stopHeadTracking()
+        }
+    }
+
+    private func startHeadTracking() {
+        if headphoneMotionManager == nil {
+            headphoneMotionManager = CMHeadphoneMotionManager()
+        }
+
+        guard let motionManager = headphoneMotionManager, !motionManager.isDeviceMotionActive else {
+            return
+        }
+
+        if !motionManager.isDeviceMotionAvailable {
+            Logger.info("Headphone motion currently unavailable; head tracking will engage when supported headphones connect")
+        }
+
+        motionManager.startDeviceMotionUpdates(to: .main) { [weak self] motion, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                // e.g. motion access denied; fall back to fixed spatialization
+                Logger.warning("Headphone motion error, disabling head tracking: \(error.localizedDescription)")
+                self.stopHeadTracking()
+                return
+            }
+
+            guard let motion = motion, self.spatialAudioEnabled, self.headTrackingEnabled else { return }
+
+            // CMAttitude: positive yaw is counterclockwise (head turning left), while
+            // AVAudio3DAngularOrientation: positive yaw is clockwise (head turning right),
+            // so yaw is negated to keep the sound stage anchored in space
+            self.environmentNode?.listenerAngularOrientation = AVAudio3DAngularOrientation(
+                yaw: -Float(motion.attitude.yaw * 180 / .pi),
+                pitch: Float(motion.attitude.pitch * 180 / .pi),
+                roll: Float(motion.attitude.roll * 180 / .pi)
+            )
+        }
+
+        Logger.info("Started headphone motion updates for head tracking")
+    }
+
+    private func stopHeadTracking() {
+        guard let motionManager = headphoneMotionManager, motionManager.isDeviceMotionActive else {
+            return
+        }
+
+        motionManager.stopDeviceMotionUpdates()
+        environmentNode?.listenerAngularOrientation = AVAudio3DAngularOrientation(yaw: 0, pitch: 0, roll: 0)
+        Logger.info("Stopped headphone motion updates")
     }
 
     private func setupStereoWidening(engine: AVAudioEngine) {

--- a/Managers/PlaybackManager.swift
+++ b/Managers/PlaybackManager.swift
@@ -288,6 +288,34 @@ class PlaybackManager: NSObject, ObservableObject {
         audioPlayer.isStereoWideningEnabled()
     }
 
+    /// Enable or disable Spatialize Stereo (spatial audio)
+    /// - Parameter enabled: true to enable, false to disable
+    func setSpatialAudio(enabled: Bool) {
+        audioPlayer.setSpatialAudio(enabled: enabled)
+        UserDefaults.standard.set(enabled, forKey: "spatialAudioEnabled")
+        Logger.info("Spatialize Stereo \(enabled ? "enabled" : "disabled") via PlaybackManager")
+    }
+
+    /// Check if spatial audio is currently enabled
+    /// - Returns: true if enabled, false otherwise
+    func isSpatialAudioEnabled() -> Bool {
+        audioPlayer.isSpatialAudioEnabled()
+    }
+
+    /// Enable or disable head tracking for spatial audio
+    /// - Parameter enabled: true to enable, false to disable
+    func setHeadTracking(enabled: Bool) {
+        audioPlayer.setHeadTracking(enabled: enabled)
+        UserDefaults.standard.set(enabled, forKey: "headTrackingEnabled")
+        Logger.info("Head tracking \(enabled ? "enabled" : "disabled") via PlaybackManager")
+    }
+
+    /// Check if head tracking is currently enabled
+    /// - Returns: true if enabled, false otherwise
+    func isHeadTrackingEnabled() -> Bool {
+        audioPlayer.isHeadTrackingEnabled()
+    }
+
     /// Enable or disable the equalizer
     /// - Parameter enabled: true to enable, false to disable
     func setEQEnabled(_ enabled: Bool) {
@@ -428,6 +456,20 @@ class PlaybackManager: NSObject, ObservableObject {
             Logger.info("Restored stereo widening: enabled")
         }
         
+        // Restore spatial audio; the head tracking flag is set first so that
+        // motion updates start as soon as spatial audio is enabled
+        let headTrackingEnabled = UserDefaults.standard.bool(forKey: "headTrackingEnabled")
+        if headTrackingEnabled {
+            audioPlayer.setHeadTracking(enabled: true)
+            Logger.info("Restored head tracking: enabled")
+        }
+
+        let spatialAudioEnabled = UserDefaults.standard.bool(forKey: "spatialAudioEnabled")
+        if spatialAudioEnabled {
+            audioPlayer.setSpatialAudio(enabled: true)
+            Logger.info("Restored Spatialize Stereo: enabled")
+        }
+
         // Restore EQ enabled state
         let eqEnabled = UserDefaults.standard.bool(forKey: "eqEnabled")
         if eqEnabled {

--- a/PetrichorApp.swift
+++ b/PetrichorApp.swift
@@ -71,7 +71,7 @@ struct PetrichorApp: App {
                 .environmentObject(appCoordinator.playbackManager)
         }
         .handlesExternalEvents(matching: [])
-        .defaultSize(width: 500, height: 300)
+        .defaultSize(width: 500, height: 330)
         .windowResizability(.contentSize)
     }
     

--- a/Views/Settings/EqualizerView.swift
+++ b/Views/Settings/EqualizerView.swift
@@ -7,6 +7,8 @@ struct EqualizerView: View {
 
     @State private var isEnabled = false
     @State private var stereoWideningEnabled = false
+    @State private var spatializeStereoEnabled = false
+    @State private var headTrackingEnabled = false
     @State private var selectedPreset: EqualizerPreset = .flat
     @State private var isCustomMode = false
     @State private var customGains: [Float] = Array(repeating: 0.0, count: 10)
@@ -19,13 +21,15 @@ struct EqualizerView: View {
     var body: some View {
         VStack(spacing: 20) {
             topControlsRow
-            
+
+            spatialAudioRow
+
             eqSlidersSection
                 .disabled(!isEnabled)
                 .opacity(isEnabled ? 1.0 : 0.5)
         }
         .padding(20)
-        .frame(width: 500, height: 300)
+        .frame(width: 500, height: 330)
         .onAppear {
             loadCurrentSettings()
         }
@@ -55,6 +59,29 @@ struct EqualizerView: View {
 
             presetPicker
                 .disabled(!isEnabled)
+        }
+    }
+
+    // MARK: - Spatial Audio Row
+
+    private var spatialAudioRow: some View {
+        HStack(spacing: 16) {
+            Toggle("Spatialize Stereo", isOn: $spatializeStereoEnabled)
+                .toggleStyle(.checkbox)
+                .onChange(of: spatializeStereoEnabled) {
+                    playbackManager.setSpatialAudio(enabled: spatializeStereoEnabled)
+                }
+                .help("Render stereo audio as immersive spatial audio when using headphones")
+
+            Toggle("Head Tracking", isOn: $headTrackingEnabled)
+                .toggleStyle(.checkbox)
+                .disabled(!spatializeStereoEnabled)
+                .onChange(of: headTrackingEnabled) {
+                    playbackManager.setHeadTracking(enabled: headTrackingEnabled)
+                }
+                .help("Keep the sound stage anchored in space as you move your head (requires AirPods with head tracking)")
+
+            Spacer()
         }
     }
 
@@ -164,6 +191,8 @@ struct EqualizerView: View {
     private func loadCurrentSettings() {
         isEnabled = playbackManager.isEQEnabled()
         stereoWideningEnabled = playbackManager.isStereoWideningEnabled()
+        spatializeStereoEnabled = playbackManager.isSpatialAudioEnabled()
+        headTrackingEnabled = playbackManager.isHeadTrackingEnabled()
         preampGain = playbackManager.getPreamp()
 
         if let presetRawValue = UserDefaults.standard.string(forKey: "eqPreset") {
@@ -231,5 +260,5 @@ private struct EqualizerWindowConfigurator: NSViewRepresentable {
                 playlistManager: playlistManager
             )
         }())
-        .frame(width: 500, height: 300)
+        .frame(width: 500, height: 330)
 }


### PR DESCRIPTION
## Summary

Implements **Spatialize Stereo** with optional **head tracking**, as requested in #115.

Since Petrichor is a native macOS app, the iOS APIs suggested in the issue (`AVAudioSession`) aren't available; this uses the macOS-native equivalents:

- An **`AVAudioEnvironmentNode`** is inserted into the existing SFBAudioEngine processing graph (`source → spatial → stereo widening → EQ → main mixer`), with `outputType = .headphones` for binaural rendering.
- Spatialization uses **`sourceMode = .ambienceBed`**, which the SDK documents as rendering the stereo channels "as far-field sources anchored to global space" — the same behavior as Apple Music's Spatialize Stereo. When disabled, `.bypass` passes audio through untouched.
- **Head tracking** integrates `CMHeadphoneMotionManager` (macOS 14+, matching the deployment target) and drives `listenerAngularOrientation` so the sound stage stays anchored in space as you move your head. The CoreMotion yaw is negated to match `AVAudio3DAngularOrientation` sign conventions. (`AVAudioEnvironmentNode.isListenerHeadTrackingEnabled` would be system-managed, but it's macOS 15+ only.)

### UI

Two new checkboxes in the Equalizer window (⌥⌘E), independent of the EQ master toggle, with tooltips:

- **Spatialize Stereo** — toggles spatial rendering
- **Head Tracking** — enabled only while Spatialize Stereo is on

Both settings persist via `UserDefaults` and restore on launch, following the existing stereo widening / EQ patterns in `PlaybackManager`.

### Graceful degradation

- Head tracking off → fixed spatialization (like Apple Music's "Fixed" mode)
- No motion-capable headphones connected → tracking engages automatically when supported AirPods connect
- Motion error / permission denied → tracking stops cleanly and resets orientation; fixed spatialization continues
- `NSMotionUsageDescription` added to Info.plist (required for headphone motion access)

### Changes

- `Core/AudioPlayer.swift` — environment node setup, spatial/head-tracking API, graph reconfiguration on format change
- `Managers/PlaybackManager.swift` — manager API, persistence, restore-on-launch
- `Views/Settings/EqualizerView.swift` — toggles UI
- `PetrichorApp.swift` — equalizer window height (300 → 330)
- `Configuration/Info.plist` — `NSMotionUsageDescription`

## Testing

- Build succeeds with no warnings (macOS 26.5 SDK, target 14.0)
- Launched the app with the feature enabled: environment node attaches, full chain wires up, setting restores from defaults
- Offline-render test of the same node chain: ambience-bed output differs from bypass output (peak 0.543 vs 0.500 on a 0.5-amplitude sine), confirming binaural processing is active and toggles live
- **Not yet done:** a real listening test with AirPods Pro/Max (head tracked + fixed). I'll report back once I've tested on hardware — in particular whether the head-tracking yaw direction feels correct (if inverted, the sign in `startHeadTracking()` needs flipping)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)