### PR TITLE
Enable native macOS spatial audio (Spatialize Stereo) for playback

### DIFF
--- a/Core/AudioEffectsChain.swift
+++ b/Core/AudioEffectsChain.swift
@@ -1,0 +1,256 @@
+import AVFoundation
+import Foundation
+
+/// Applies the in-app audio effects (stereo widening, equalizer, preamp) to decoded
+/// PCM using an `AVAudioEngine` in offline manual rendering mode.
+///
+/// The playback output runs through `AVSampleBufferAudioRenderer` (see
+/// `SpatialAudioRenderer`), which has no insert-effect graph of its own, so effects
+/// are rendered into the PCM before it is enqueued. Decoder formats that are not
+/// Float32 deinterleaved (e.g. Int16 interleaved from WAV/AIFF) are converted on the
+/// way in. When no effect is enabled the input buffers pass through untouched
+/// (bit-exact, no conversion).
+final class AudioEffectsChain {
+
+    // MARK: - Private Properties
+
+    private let engine = AVAudioEngine()
+    private var sourceNode: AVAudioSourceNode?
+    private var delayNode: AVAudioUnitDelay?
+    private var eqNode: AVAudioUnitEQ?
+
+    /// The decoder's format accepted by `process(_:)`
+    private var sourceFormat: AVAudioFormat?
+    /// Standard Float32 deinterleaved format the graph renders in
+    private var chainFormat: AVAudioFormat?
+    private var inputConverter: AVAudioConverter?
+    private var convertedBuffer: AVAudioPCMBuffer?
+    private var outputBuffer: AVAudioPCMBuffer?
+
+    /// Input handoff to the source node render block (always in `chainFormat`)
+    private var pendingBuffer: AVAudioPCMBuffer?
+    private var pendingOffset: Int = 0
+
+    private static let maximumFrames: AVAudioFrameCount = 8192
+    private let eqFrequencies: [Float] = [32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
+
+    // MARK: - Effect State
+
+    /// Effect settings survive engine rebuilds on format changes
+    private(set) var stereoWideningEnabled = false
+    private(set) var eqEnabled = false
+    private(set) var eqGains = [Float](repeating: 0, count: 10)
+    private(set) var preampGain: Float = 0
+
+    /// True when at least one effect needs rendering
+    var isActive: Bool {
+        stereoWideningEnabled || eqEnabled
+    }
+
+    // MARK: - Effect Control
+
+    func setStereoWidening(enabled: Bool) {
+        stereoWideningEnabled = enabled
+        delayNode?.bypass = !enabled
+    }
+
+    func setEQEnabled(_ enabled: Bool) {
+        eqEnabled = enabled
+        eqNode?.bypass = !enabled
+    }
+
+    func setEQGains(_ gains: [Float]) {
+        guard gains.count == eqGains.count else { return }
+        eqGains = gains
+        if let eqNode {
+            for (index, gain) in gains.enumerated() {
+                eqNode.bands[index].gain = gain
+            }
+        }
+    }
+
+    func setPreamp(_ gain: Float) {
+        preampGain = gain
+        eqNode?.globalGain = gain
+    }
+
+    // MARK: - Rendering
+
+    /// Rebuilds the chain when the decoder format changes; called from the decode queue
+    func configure(format: AVAudioFormat) {
+        guard sourceFormat != format else { return }
+
+        teardown()
+
+        guard let chainFormat = AVAudioFormat(
+            standardFormatWithSampleRate: format.sampleRate,
+            channels: format.channelCount
+        ) else {
+            Logger.error("Effects chain unavailable for format: \(format)")
+            return
+        }
+
+        if format == chainFormat {
+            inputConverter = nil
+            convertedBuffer = nil
+        } else {
+            guard let converter = AVAudioConverter(from: format, to: chainFormat),
+                  let buffer = AVAudioPCMBuffer(pcmFormat: chainFormat, frameCapacity: Self.maximumFrames) else {
+                Logger.error("Effects chain cannot convert from format: \(format)")
+                return
+            }
+            inputConverter = converter
+            convertedBuffer = buffer
+        }
+
+        let source = AVAudioSourceNode(format: chainFormat) { [weak self] _, _, frameCount, audioBufferList in
+            self?.renderPendingInput(frameCount: frameCount, into: audioBufferList) ?? noErr
+        }
+
+        // Haas effect stereo widening, matching the previous AVAudioEngine graph
+        let delay = AVAudioUnitDelay()
+        delay.delayTime = 0.020
+        delay.wetDryMix = 50
+        delay.feedback = -10
+        delay.lowPassCutoff = 15000
+        delay.bypass = !stereoWideningEnabled
+
+        let eq = AVAudioUnitEQ(numberOfBands: 10)
+        for (index, frequency) in eqFrequencies.enumerated() {
+            let band = eq.bands[index]
+            band.filterType = .parametric
+            band.frequency = frequency
+            band.bandwidth = 1.0
+            band.gain = eqGains[index]
+            band.bypass = false
+        }
+        eq.globalGain = preampGain
+        eq.bypass = !eqEnabled
+
+        do {
+            // Manual rendering mode must be enabled before connecting nodes so the
+            // graph is detached from the hardware output device
+            try engine.enableManualRenderingMode(.offline, format: chainFormat, maximumFrameCount: Self.maximumFrames)
+
+            engine.attach(source)
+            engine.attach(delay)
+            engine.attach(eq)
+            engine.connect(source, to: delay, format: chainFormat)
+            engine.connect(delay, to: eq, format: chainFormat)
+            engine.connect(eq, to: engine.mainMixerNode, format: chainFormat)
+
+            try engine.start()
+        } catch {
+            Logger.error("Failed to start audio effects chain: \(error.localizedDescription)")
+            engine.stop()
+            engine.detach(source)
+            engine.detach(delay)
+            engine.detach(eq)
+            inputConverter = nil
+            convertedBuffer = nil
+            return
+        }
+
+        sourceNode = source
+        delayNode = delay
+        eqNode = eq
+        outputBuffer = AVAudioPCMBuffer(pcmFormat: chainFormat, frameCapacity: Self.maximumFrames)
+        sourceFormat = format
+        self.chainFormat = chainFormat
+        Logger.info("Audio effects chain configured: \(format.sampleRate)Hz, \(format.channelCount)ch")
+    }
+
+    /// Runs a decoded buffer through the effect chain; returns the input unchanged
+    /// when no effect is enabled or the chain is unavailable. Called from the decode queue.
+    func process(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer {
+        guard isActive else { return buffer }
+        guard let sourceFormat, sourceFormat == buffer.format,
+              let outputBuffer, engine.isRunning,
+              buffer.frameLength <= Self.maximumFrames else {
+            return buffer
+        }
+
+        let chainInput: AVAudioPCMBuffer
+        if let inputConverter, let convertedBuffer {
+            convertedBuffer.frameLength = 0
+            do {
+                try inputConverter.convert(to: convertedBuffer, from: buffer)
+            } catch {
+                Logger.error("Effects chain input conversion failed: \(error.localizedDescription)")
+                return buffer
+            }
+            guard convertedBuffer.frameLength == buffer.frameLength else { return buffer }
+            chainInput = convertedBuffer
+        } else {
+            chainInput = buffer
+        }
+
+        pendingBuffer = chainInput
+        pendingOffset = 0
+        outputBuffer.frameLength = 0
+
+        do {
+            let status = try engine.renderOffline(buffer.frameLength, to: outputBuffer)
+            guard status == .success, outputBuffer.frameLength == buffer.frameLength else {
+                Logger.warning("Effects chain render incomplete (\(String(describing: status))), bypassing")
+                return buffer
+            }
+            return outputBuffer
+        } catch {
+            Logger.error("Effects chain render failed: \(error.localizedDescription)")
+            return buffer
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func teardown() {
+        engine.stop()
+        if let sourceNode { engine.detach(sourceNode) }
+        if let delayNode { engine.detach(delayNode) }
+        if let eqNode { engine.detach(eqNode) }
+        sourceNode = nil
+        delayNode = nil
+        eqNode = nil
+        inputConverter = nil
+        convertedBuffer = nil
+        outputBuffer = nil
+        pendingBuffer = nil
+        sourceFormat = nil
+        chainFormat = nil
+    }
+
+    /// Source node render block: supplies the pending input buffer to the engine
+    private func renderPendingInput(
+        frameCount: AVAudioFrameCount,
+        into audioBufferList: UnsafeMutablePointer<AudioBufferList>
+    ) -> OSStatus {
+        let outputBuffers = UnsafeMutableAudioBufferListPointer(audioBufferList)
+
+        guard let pendingBuffer, let channelData = pendingBuffer.floatChannelData else {
+            for outputBuffer in outputBuffers where outputBuffer.mData != nil {
+                memset(outputBuffer.mData, 0, Int(outputBuffer.mDataByteSize))
+            }
+            return noErr
+        }
+
+        let available = Int(pendingBuffer.frameLength) - pendingOffset
+        let framesToCopy = max(0, min(Int(frameCount), available))
+
+        for (channel, outputBuffer) in outputBuffers.enumerated() {
+            guard let destination = outputBuffer.mData else { continue }
+            let source = channelData[min(channel, Int(pendingBuffer.format.channelCount) - 1)]
+
+            if framesToCopy > 0 {
+                memcpy(destination, source + pendingOffset, framesToCopy * MemoryLayout<Float>.size)
+            }
+            if framesToCopy < Int(frameCount) {
+                let remainder = destination + framesToCopy * MemoryLayout<Float>.size
+                memset(remainder, 0, (Int(frameCount) - framesToCopy) * MemoryLayout<Float>.size)
+            }
+        }
+
+        pendingOffset += framesToCopy
+        return noErr
+    }
+}

--- a/Core/AudioPlayer.swift
+++ b/Core/AudioPlayer.swift
@@ -2,10 +2,6 @@ import AVFoundation
 import Foundation
 import SFBAudioEngine
 
-typealias SFBPlayer = SFBAudioEngine.AudioPlayer
-typealias SFBPlayerPlaybackState = SFBAudioEngine.AudioPlayer.PlaybackState
-typealias SFBDecoding = SFBAudioEngine.PCMDecoding
-
 // MARK: - Audio Player State
 
 public enum AudioPlayerState {
@@ -89,6 +85,14 @@ public extension AudioPlayerDelegate {
 
 // MARK: - PAudioPlayer
 
+/// Audio player that decodes with SFBAudioEngine and renders through
+/// `SpatialAudioRenderer` (`AVSampleBufferAudioRenderer`).
+///
+/// Rendering through `AVSampleBufferAudioRenderer` makes the audio eligible for
+/// macOS system-level Spatial Audio: with AirPods (3rd gen)/Pro/Max connected, the
+/// Sound menu offers Spatialize Stereo (Fixed / Head Tracked) and the OS performs
+/// the spatialization and head tracking natively — no app configuration required,
+/// matching the behavior of Apple Music and other AVFoundation-based players.
 public class PAudioPlayer: NSObject {
     
     // MARK: - Public Properties
@@ -97,14 +101,10 @@ public class PAudioPlayer: NSObject {
     
     public var volume: Float {
         get {
-            return sfbPlayer.volume
+            return renderer.volume
         }
         set {
-            do {
-                try sfbPlayer.setVolume(newValue)
-            } catch {
-                Logger.error("Failed to set volume: \(error)")
-            }
+            renderer.volume = newValue
         }
     }
     
@@ -120,12 +120,12 @@ public class PAudioPlayer: NSObject {
     
     /// Current playback progress in seconds
     public var currentPlaybackProgress: Double {
-        sfbPlayer.currentTime ?? 0
+        renderer.currentTime
     }
     
     /// Total duration of current file in seconds
     public var duration: Double {
-        sfbPlayer.totalTime ?? 0
+        renderer.duration
     }
     
     /// Legacy property name for backwards compatibility
@@ -135,41 +135,24 @@ public class PAudioPlayer: NSObject {
     
     // MARK: - Private Properties
     
-    private let sfbPlayer: SFBPlayer
+    private let renderer = SpatialAudioRenderer()
     private var currentEntryId: AudioEntryId?
     private var currentURL: URL?
-    private var delegateBridge: SFBAudioPlayerDelegateBridge?
     private static let maxPreBufferSize: UInt64 = 100 * 1024 * 1024
     
-    // MARK: - Audio Effects Nodes
-
-    private var effectsAttached = false
-
-    /// Stereo Widening
-    private var stereoWideningEnabled: Bool = false
-    private var stereoWideningNode: AVAudioUnit?
-
-    /// Equalizer
-    private var eqEnabled: Bool = false
-    private var eqNode: AVAudioUnitEQ?
-    private var preampGain: Float = 0.0
+    /// Equalizer preamp state (the gain compensation policy lives here; the
+    /// effect nodes live in the renderer's effects chain)
     private var userPreampGain: Float = 0.0
-    private var currentEQGains: [Float] = Array(repeating: 0.0, count: 10)
-    private let eqFrequencies: [Float] = [32, 64, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
     
     // MARK: - Initialization
     
     public override init() {
-        self.sfbPlayer = SFBPlayer()
         super.init()
-        
-        // Create and set up the delegate bridge for playback event monitoring
-        self.delegateBridge = SFBAudioPlayerDelegateBridge(owner: self)
-        self.sfbPlayer.delegate = self.delegateBridge
+        renderer.delegate = self
     }
     
     deinit {
-        sfbPlayer.stop()
+        renderer.stop()
     }
     
     // MARK: - Playback Control
@@ -184,64 +167,36 @@ public class PAudioPlayer: NSObject {
         currentEntryId = entryId
         
         let shouldPreBuffer = Self.shouldPreBuffer(url: url)
-        
-        if shouldPreBuffer {
             state = .ready
             
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let self = self else { return }
                 
                 do {
-                    let inputSource = try InputSource(for: url, flags: .loadFilesInMemory)
-                    let decoder = try AudioDecoder(inputSource: inputSource)
-                    
-                    try self.sfbPlayer.play(decoder)
+                let decoder = try Self.makeDecoder(for: url, preBuffer: shouldPreBuffer)
+                try decoder.open()
                     
                     DispatchQueue.main.async {
+                    // Ignore the result of a stale load if another track started meanwhile
+                    guard self.currentEntryId == entryId else { return }
+
+                    do {
+                        try self.renderer.play(decoder: decoder, startPaused: startPaused)
                         if startPaused {
-                            self.sfbPlayer.pause()
                             self.state = .paused
                         } else {
-                            self.state = .playing
+                            self.notifyPlaybackStarted()
                         }
-                        Logger.info("Started playing (pre-buffered): \(url.lastPathComponent)")
+                        Logger.info("Started playing\(shouldPreBuffer ? " (pre-buffered)" : ""): \(url.lastPathComponent)")
+                    } catch {
+                        self.handlePlaybackError(error, entryId: entryId)
                     }
-                } catch {
-                    Logger.warning("Pre-buffering failed, falling back to direct playback: \(error.localizedDescription)")
-                    
-                    do {
-                        try self.sfbPlayer.play(url)
-                        
-                        DispatchQueue.main.async {
-                            if startPaused {
-                                self.sfbPlayer.pause()
-                                self.state = .paused
-                            } else {
-                                self.state = .playing
-                            }
-                            Logger.info("Started playing (direct fallback): \(url.lastPathComponent)")
                         }
                     } catch {
                         DispatchQueue.main.async {
+                    guard self.currentEntryId == entryId else { return }
                             self.handlePlaybackError(error, entryId: entryId)
                         }
-                    }
-                }
-            }
-        } else {
-            do {
-                try sfbPlayer.play(url)
-                
-                if startPaused {
-                    sfbPlayer.pause()
-                    state = .paused
-                } else {
-                    state = .playing
-                }
-                
-                Logger.info("Started playing: \(url.lastPathComponent)")
-            } catch {
-                handlePlaybackError(error, entryId: entryId)
             }
         }
     }
@@ -249,7 +204,7 @@ public class PAudioPlayer: NSObject {
     /// Pause playback
     public func pause() {
         guard state == .playing else { return }
-        sfbPlayer.pause()
+        renderer.pause()
         state = .paused
         Logger.info("Playback paused")
     }
@@ -257,15 +212,9 @@ public class PAudioPlayer: NSObject {
     /// Resume playback
     public func resume() {
         guard state == .paused else { return }
-        
-        do {
-            try sfbPlayer.play()
-            state = .playing
+        renderer.resume()
+        notifyPlaybackStarted()
             Logger.info("Playback resumed")
-        } catch {
-            Logger.error("Failed to resume playback: \(error)")
-            delegate?.audioPlayerUnexpectedError(player: self, error: .engineError(error))
-        }
     }
     
     /// Stop playback
@@ -277,7 +226,7 @@ public class PAudioPlayer: NSObject {
         let currentDuration = duration
         let entryId = currentEntryId
         
-        sfbPlayer.stop()
+        renderer.stop()
         state = .stopped
         
         if wasPlaying, let entryId = entryId {
@@ -298,23 +247,13 @@ public class PAudioPlayer: NSObject {
     
     /// Toggle between play and pause
     public func togglePlayPause() {
-        do {
-            try sfbPlayer.togglePlayPause()
-            
-            // Update state based on current playback state
-            switch sfbPlayer.playbackState {
+        switch state {
             case .playing:
-                state = .playing
+            pause()
             case .paused:
-                state = .paused
-            case .stopped:
-                state = .stopped
-            @unknown default:
+            resume()
+        default:
                 break
-            }
-        } catch {
-            Logger.error("Failed to toggle play/pause: \(error)")
-            delegate?.audioPlayerUnexpectedError(player: self, error: .engineError(error))
         }
     }
     
@@ -325,7 +264,7 @@ public class PAudioPlayer: NSObject {
     public func seek(to time: Double) -> Bool {
         guard time >= 0 else { return false }
         
-        let success = sfbPlayer.seek(time: time)
+        let success = renderer.seek(to: time)
         
         if !success {
             Logger.error("Failed to seek to time: \(time)")
@@ -340,7 +279,7 @@ public class PAudioPlayer: NSObject {
     /// - Returns: true if seek was successful
     @discardableResult
     public func seekForward(_ seconds: Double) -> Bool {
-        return sfbPlayer.seek(forward: seconds)
+        return seek(to: currentPlaybackProgress + seconds)
     }
     
     /// Seek backward by a number of seconds
@@ -348,7 +287,7 @@ public class PAudioPlayer: NSObject {
     /// - Returns: true if seek was successful
     @discardableResult
     public func seekBackward(_ seconds: Double) -> Bool {
-        return sfbPlayer.seek(backward: seconds)
+        return seek(to: max(0, currentPlaybackProgress - seconds))
     }
     
     // MARK: - Audio Equalizer
@@ -356,64 +295,35 @@ public class PAudioPlayer: NSObject {
     /// Enable or disable stereo widening effect
     /// - Parameter enabled: boolean for the current state of stereo widening
     public func setStereoWidening(enabled: Bool) {
-        stereoWideningEnabled = enabled
-        
-        if !effectsAttached {
-            setupAudioEffects()
-        }
-        
-        if let effectNode = stereoWideningNode as? AVAudioUnitEffect {
-            effectNode.bypass = !enabled
-        }
-        
+        renderer.effects.setStereoWidening(enabled: enabled)
         Logger.info("Stereo Widening \(enabled ? "enabled" : "disabled")")
     }
 
     /// Check if stereo widening is currently enabled
     /// - Returns: true if Stereo Widening is enabled, false otherwise
     public func isStereoWideningEnabled() -> Bool {
-        return stereoWideningEnabled
+        return renderer.effects.stereoWideningEnabled
     }
     
     /// Enable or disable the equalizer
     /// - Parameter enabled: boolean for the current state Equalizer
     public func setEQEnabled(_ enabled: Bool) {
-        eqEnabled = enabled
-        
-        if !effectsAttached {
-            setupAudioEffects()
-        }
-        
-        eqNode?.bypass = !enabled
-        
+        renderer.effects.setEQEnabled(enabled)
         applyEffectivePreamp()
-        
         Logger.info("Audio Equalizer \(enabled ? "enabled" : "disabled")")
     }
     
     /// Check if EQ is currently enabled
     /// - Returns: true if Equalizer is enabled, false otherwise
     public func isEQEnabled() -> Bool {
-        return eqEnabled
+        return renderer.effects.eqEnabled
     }
     
     /// Apply an EQ preset
     /// - Parameter preset: The EqualizerPreset to apply
     public func applyEQPreset(_ preset: EqualizerPreset) {
-        currentEQGains = preset.gains
-        
-        if !effectsAttached {
-            setupAudioEffects()
-        }
-        
-        if let eq = eqNode {
-            for (index, gain) in currentEQGains.enumerated() {
-                eq.bands[index].gain = gain
-            }
-        }
-        
+        renderer.effects.setEQGains(preset.gains)
         applyEffectivePreamp()
-        
         Logger.info("Applied Equalizer preset: \(preset.displayName)")
     }
     
@@ -425,20 +335,8 @@ public class PAudioPlayer: NSObject {
             return
         }
         
-        currentEQGains = gains
-        
-        if !effectsAttached {
-            setupAudioEffects()
-        }
-        
-        if let eq = eqNode {
-            for (index, gain) in gains.enumerated() {
-                eq.bands[index].gain = gain
-            }
-        }
-        
+        renderer.effects.setEQGains(gains)
         applyEffectivePreamp()
-        
         Logger.info("Applied custom Equalizer gains")
     }
     
@@ -448,7 +346,7 @@ public class PAudioPlayer: NSObject {
     public func setPreamp(_ gain: Float) {
         userPreampGain = max(-12.0, min(12.0, gain))
         applyEffectivePreamp()
-        Logger.info("Preamp set to \(userPreampGain) dB (effective: \(preampGain) dB)")
+        Logger.info("Preamp set to \(userPreampGain) dB")
     }
 
     /// Get the current preamp gain value
@@ -457,35 +355,32 @@ public class PAudioPlayer: NSObject {
         return userPreampGain
     }
     
-    // MARK: - Internal Methods (called by delegate bridge)
+    // MARK: - Private Methods
     
-    internal func handlePlaybackStateChanged(_ newState: SFBPlayerPlaybackState) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            
-            switch newState {
-            case .playing:
-                if self.state != .playing {
-                    self.state = .playing
-                    if let entryId = self.currentEntryId {
-                        self.delegate?.audioPlayerDidStartPlaying(player: self, with: entryId)
+    /// Creates a decoder for the URL, loading the file into memory when pre-buffering
+    private static func makeDecoder(for url: URL, preBuffer: Bool) throws -> AudioDecoder {
+        if preBuffer {
+            do {
+                let inputSource = try InputSource(for: url, flags: .loadFilesInMemory)
+                return try AudioDecoder(inputSource: inputSource)
+            } catch {
+                Logger.warning("Pre-buffering failed, falling back to direct decoding: \(error.localizedDescription)")
                     }
                 }
-            case .paused:
-                if self.state != .paused {
-                    self.state = .paused
+        return try AudioDecoder(url: url)
                 }
-            case .stopped:
-                if self.state != .stopped {
-                    self.state = .stopped
-                }
-            @unknown default:
-                break
-            }
+
+    /// Fires didStartPlaying on transitions into the playing state
+    private func notifyPlaybackStarted() {
+        guard state != .playing else { return }
+        state = .playing
+        if let entryId = currentEntryId {
+            delegate?.audioPlayerDidStartPlaying(player: self, with: entryId)
         }
     }
     
-    internal func handleEndOfAudio() {
+    /// Common end-of-track handling
+    private func finishCurrentTrack() {
         let finalProgress = currentPlaybackProgress
         let finalDuration = duration
         
@@ -507,54 +402,6 @@ public class PAudioPlayer: NSObject {
             }
         }
     }
-    
-    /// Reconfigures the audio processing graph when the format changes
-    /// This is called by SFBAudioEngine when switching between different sample rates
-    internal func reconfigureAudioGraph(engine: AVAudioEngine, format: AVAudioFormat) -> AVAudioNode {
-        Logger.info("Reconfiguring audio graph for format: \(format.sampleRate)Hz, \(format.channelCount)ch")
-        
-        guard effectsAttached else {
-            Logger.info("No effects attached, connecting directly to mixer")
-            return engine.mainMixerNode
-        }
-        
-        // Detach and recreate effect nodes with the new format
-        if let oldStereoNode = stereoWideningNode {
-            engine.detach(oldStereoNode)
-            stereoWideningNode = nil
-        }
-        
-        if let oldEQNode = eqNode {
-            engine.detach(oldEQNode)
-            eqNode = nil
-        }
-        
-        // Recreate the effects chain
-        setupStereoWidening(engine: engine)
-        setupEqualizer(engine: engine)
-        
-        let mainMixer = engine.mainMixerNode
-        
-        if let stereoNode = stereoWideningNode, let equalizer = eqNode {
-            engine.connect(stereoNode, to: equalizer, format: format)
-            engine.connect(equalizer, to: mainMixer, format: format)
-            Logger.info("Reconfigured audio graph: playerNode -> stereoWidening -> EQ -> mainMixer")
-            
-            return stereoNode
-        }
-        
-        Logger.warning("Failed to reconfigure effects chain, falling back to mixer")
-        return mainMixer
-    }
-    
-    internal func handleError(_ error: Error) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.delegate?.audioPlayerUnexpectedError(player: self, error: .engineError(error))
-        }
-    }
-    
-    // MARK: - Private Methods
     
     private static func shouldPreBuffer(url: URL) -> Bool {
         // Only consider pre-buffering for files under the size threshold
@@ -593,78 +440,10 @@ public class PAudioPlayer: NSObject {
         )
     }
     
-    private func setupAudioEffects() {
-        guard !effectsAttached else {
-            Logger.info("Audio effects already attached")
-            return
-        }
-        
-        let sourceNode = sfbPlayer.sourceNode
-        let mainMixer = sfbPlayer.mainMixerNode
-        let format = sourceNode.outputFormat(forBus: 0)
-        
-        Logger.info("Setting up audio effects...")
-        Logger.info("Source node: \(sourceNode), Format: \(format.sampleRate)Hz, \(format.channelCount)ch")
-        
-        sfbPlayer.modifyProcessingGraph { [self] engine in
-            setupStereoWidening(engine: engine)
-            setupEqualizer(engine: engine)
-            
-            guard let stereoNode = stereoWideningNode, let equalizer = eqNode else {
-                Logger.warning("Failed to create effect nodes")
-                return
-            }
-            
-            // Disconnect sourceNode from mainMixer
-            engine.disconnectNodeOutput(sourceNode)
-            
-            // Connect: sourceNode -> stereoWidening -> EQ -> mainMixer
-            engine.connect(sourceNode, to: stereoNode, format: format)
-            engine.connect(stereoNode, to: equalizer, format: format)
-            engine.connect(equalizer, to: mainMixer, format: format)
-            
-            effectsAttached = true
-            Logger.info("Audio effects setup complete")
-        }
-    }
-
-    private func setupStereoWidening(engine: AVAudioEngine) {
-        let delay = AVAudioUnitDelay()
-        delay.delayTime = 0.020
-        delay.wetDryMix = 50
-        delay.feedback = -10
-        delay.lowPassCutoff = 15000
-        delay.bypass = !stereoWideningEnabled
-        
-        engine.attach(delay)
-        self.stereoWideningNode = delay
-
-        Logger.info("Attached delay node (Haas effect stereo widening)")
-    }
-
-    private func setupEqualizer(engine: AVAudioEngine) {
-        let eq = AVAudioUnitEQ(numberOfBands: 10)
-        
-        for (index, frequency) in eqFrequencies.enumerated() {
-            let band = eq.bands[index]
-            band.filterType = .parametric
-            band.frequency = frequency
-            band.bandwidth = 1.0
-            band.gain = currentEQGains[index]
-            band.bypass = false
-        }
-        eq.globalGain = preampGain
-        eq.bypass = !eqEnabled
-        
-        engine.attach(eq)
-        self.eqNode = eq
-        Logger.info("Attached EQ node to engine")
-    }
-    
     private func calculateGainCompensation() -> Float {
-        guard eqEnabled else { return 0 }
+        guard renderer.effects.eqEnabled else { return 0 }
         
-        let maxBandGain = currentEQGains.max() ?? 0
+        let maxBandGain = renderer.effects.eqGains.max() ?? 0
         
         if maxBandGain > 0 {
             // Offset max gain to prevent audio
@@ -676,50 +455,21 @@ public class PAudioPlayer: NSObject {
     
     private func applyEffectivePreamp() {
         let compensation = calculateGainCompensation()
-        preampGain = userPreampGain + compensation
-        
-        if !effectsAttached {
-            setupAudioEffects()
-        }
-        
-        eqNode?.globalGain = preampGain
+        renderer.effects.setPreamp(userPreampGain + compensation)
     }
 }
 
-// MARK: - Private Delegate Bridge
+// MARK: - SpatialAudioRendererDelegate
 
-/// Internal class that bridges SFBAudioEngine delegate callbacks to PAudioPlayer
-private class SFBAudioPlayerDelegateBridge: NSObject, SFBAudioEngine.AudioPlayer.Delegate {
-    weak var owner: PAudioPlayer?
-    
-    init(owner: PAudioPlayer) {
-        self.owner = owner
-        super.init()
+extension PAudioPlayer: SpatialAudioRendererDelegate {
+    func spatialAudioRendererDidReachEnd(_ renderer: SpatialAudioRenderer) {
+        finishCurrentTrack()
     }
     
-    func audioPlayer(
-        _ audioPlayer: SFBAudioEngine.AudioPlayer,
-        playbackStateChanged playbackState: SFBAudioEngine.AudioPlayer.PlaybackState
-    ) {
-        owner?.handlePlaybackStateChanged(playbackState)
+    func spatialAudioRenderer(_ renderer: SpatialAudioRenderer, encounteredError error: Error) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.audioPlayerUnexpectedError(player: self, error: .engineError(error))
     }
-    
-    func audioPlayerEndOfAudio(_ audioPlayer: SFBAudioEngine.AudioPlayer) {
-        owner?.handleEndOfAudio()
-    }
-    
-    func audioPlayer(
-        _ audioPlayer: SFBAudioEngine.AudioPlayer,
-        encounteredError error: Error
-    ) {
-        owner?.handleError(error)
-    }
-    
-    func audioPlayer(
-        _ audioPlayer: SFBAudioEngine.AudioPlayer,
-        reconfigureProcessingGraph engine: AVAudioEngine,
-        with format: AVAudioFormat
-    ) -> AVAudioNode {
-        owner?.reconfigureAudioGraph(engine: engine, format: format) ?? engine.mainMixerNode
-    }
+}
 }

--- a/Core/SpatialAudioRenderer.swift
+++ b/Core/SpatialAudioRenderer.swift
@@ -1,0 +1,337 @@
+import AVFoundation
+import Foundation
+import SFBAudioEngine
+
+// MARK: - Delegate Protocol
+
+/// Delegate protocol for receiving SpatialAudioRenderer playback events
+protocol SpatialAudioRendererDelegate: AnyObject {
+    /// Called on the main queue when the renderer finishes playing the current decoder
+    func spatialAudioRendererDidReachEnd(_ renderer: SpatialAudioRenderer)
+    /// Called when the renderer encounters an unrecoverable error
+    func spatialAudioRenderer(_ renderer: SpatialAudioRenderer, encounteredError error: Error)
+}
+
+// MARK: - SpatialAudioRenderer
+
+/// Output engine that renders decoded PCM through `AVSampleBufferAudioRenderer`.
+///
+/// Unlike `AVAudioEngine`, audio rendered through `AVSampleBufferAudioRenderer` is
+/// eligible for macOS system-level Spatial Audio: when AirPods (3rd gen)/Pro/Max are
+/// connected, the Sound menu offers "Spatialize Stereo" (Fixed / Head Tracked) and the
+/// OS performs the spatialization and head tracking natively, exactly like Apple Music.
+final class SpatialAudioRenderer {
+    weak var delegate: SpatialAudioRendererDelegate?
+
+    /// In-app effects (stereo widening, EQ, preamp) applied to PCM before enqueueing
+    let effects = AudioEffectsChain()
+
+    // MARK: - Private Properties
+
+    private let renderer = AVSampleBufferAudioRenderer()
+    private let synchronizer = AVSampleBufferRenderSynchronizer()
+    private let decodeQueue = DispatchQueue(label: "org.Petrichor.SpatialAudioRenderer", qos: .userInitiated)
+
+    private var decoder: PCMDecoding?
+    private var framesDecoded: AVAudioFramePosition = 0
+    private var decodingComplete = false
+    private var endObserver: Any?
+    private var rendererStatusObservation: NSKeyValueObservation?
+
+    /// Converter used to interleave PCM before enqueueing (cached per input format)
+    private var interleaveConverter: AVAudioConverter?
+
+    /// Incremented on every play/stop so stale media-request callbacks are ignored
+    private var generation = 0
+
+    /// Number of frames decoded per enqueued sample buffer
+    private static let framesPerChunk: AVAudioFrameCount = 4096
+
+    // MARK: - Public Properties
+
+    var volume: Float {
+        get { renderer.volume }
+        set { renderer.volume = newValue }
+    }
+
+    /// Current playback position in seconds
+    var currentTime: Double {
+        let seconds = synchronizer.currentTime().seconds
+        guard seconds.isFinite, seconds > 0 else { return 0 }
+        return duration > 0 ? min(seconds, duration) : seconds
+    }
+
+    /// Duration of the current track in seconds
+    var duration: Double {
+        decodeQueue.sync {
+            guard let decoder, decoder.length > 0, decoder.processingFormat.sampleRate > 0 else { return 0 }
+            return Double(decoder.length) / decoder.processingFormat.sampleRate
+        }
+    }
+
+    var isPlaying: Bool {
+        synchronizer.rate > 0
+    }
+
+    // MARK: - Initialization
+
+    init() {
+        synchronizer.addRenderer(renderer)
+
+        // Allow the OS to spatialize any decodable layout; this is what makes
+        // "Spatialize Stereo" appear in the Sound menu instead of "Not Available"
+        renderer.allowedAudioSpatializationFormats = .monoStereoAndMultichannel
+
+        rendererStatusObservation = renderer.observe(\.status) { [weak self] renderer, _ in
+            guard let self = self, renderer.status == .failed else { return }
+            let error = renderer.error ?? NSError(domain: AVFoundationErrorDomain, code: AVError.unknown.rawValue)
+            Logger.error("Spatial audio renderer failed: \(error.localizedDescription)")
+            self.delegate?.spatialAudioRenderer(self, encounteredError: error)
+        }
+    }
+
+    deinit {
+        rendererStatusObservation?.invalidate()
+        removeEndObserver()
+    }
+
+    // MARK: - Playback Control
+
+    /// Starts playing the given decoder from its current position
+    func play(decoder: PCMDecoding, startPaused: Bool = false) throws {
+        if !decoder.isOpen {
+            try decoder.open()
+        }
+
+        let startTime: CMTime = try decodeQueue.sync {
+            generation += 1
+            renderer.stopRequestingMediaData()
+            renderer.flush()
+            removeEndObserver()
+
+            guard decoder.processingFormat.sampleRate > 0 else {
+                throw AudioPlayerError.invalidFormat
+            }
+
+            self.decoder = decoder
+            framesDecoded = max(decoder.position, 0)
+            decodingComplete = false
+            effects.configure(format: decoder.processingFormat)
+            return CMTime(value: framesDecoded, timescale: CMTimeScale(decoder.processingFormat.sampleRate))
+        }
+
+        synchronizer.setRate(startPaused ? 0 : 1, time: startTime)
+        decodeQueue.sync { startRequestingMedia() }
+    }
+
+    func pause() {
+        synchronizer.rate = 0
+    }
+
+    func resume() {
+        synchronizer.rate = 1
+    }
+
+    func stop() {
+        decodeQueue.sync {
+            generation += 1
+            renderer.stopRequestingMediaData()
+            renderer.flush()
+            removeEndObserver()
+            decoder = nil
+            framesDecoded = 0
+            decodingComplete = false
+        }
+        synchronizer.rate = 0
+    }
+
+    /// Seeks to the given time in seconds
+    /// - Returns: true if the seek succeeded
+    @discardableResult
+    func seek(to time: Double) -> Bool {
+        decodeQueue.sync {
+            guard let decoder, decoder.supportsSeeking else { return false }
+
+            let sampleRate = decoder.processingFormat.sampleRate
+            var targetFrame = AVAudioFramePosition(time * sampleRate)
+            if decoder.length > 0 {
+                targetFrame = min(max(targetFrame, 0), decoder.length)
+            }
+
+            do {
+                renderer.stopRequestingMediaData()
+                renderer.flush()
+                removeEndObserver()
+                try decoder.seek(to: targetFrame)
+            } catch {
+                Logger.error("Spatial audio renderer seek failed: \(error.localizedDescription)")
+                startRequestingMedia()
+                return false
+            }
+
+            framesDecoded = targetFrame
+            decodingComplete = false
+
+            let rate = synchronizer.rate
+            synchronizer.setRate(rate, time: CMTime(value: targetFrame, timescale: timescale))
+            startRequestingMedia()
+            return true
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private var timescale: CMTimeScale {
+        CMTimeScale(decoder?.processingFormat.sampleRate ?? 44100)
+    }
+
+    private func startRequestingMedia() {
+        let requestGeneration = generation
+        renderer.requestMediaDataWhenReady(on: decodeQueue) { [weak self] in
+            guard let self = self, self.generation == requestGeneration else { return }
+            self.provideMedia()
+        }
+    }
+
+    /// Decodes and enqueues audio while the renderer wants more data; runs on decodeQueue
+    private func provideMedia() {
+        guard let decoder, !decodingComplete else { return }
+
+        let format = decoder.processingFormat
+
+        while renderer.isReadyForMoreMediaData {
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: Self.framesPerChunk) else {
+                finishDecoding()
+                return
+            }
+
+            do {
+                try decoder.decode(into: buffer, length: Self.framesPerChunk)
+            } catch {
+                Logger.error("Spatial audio renderer decode failed: \(error.localizedDescription)")
+                finishDecoding()
+                delegate?.spatialAudioRenderer(self, encounteredError: error)
+                return
+            }
+
+            guard buffer.frameLength > 0 else {
+                finishDecoding()
+                return
+            }
+
+            let processed = effects.process(buffer)
+
+            guard let interleaved = interleavedIfNeeded(processed) else {
+                Logger.error("Failed to interleave audio for the sample buffer renderer")
+                finishDecoding()
+                return
+            }
+
+            let presentationTime = CMTime(value: framesDecoded, timescale: CMTimeScale(format.sampleRate))
+            guard let sampleBuffer = makeSampleBuffer(from: interleaved, presentationTime: presentationTime) else {
+                Logger.error("Failed to create sample buffer for spatial audio renderer")
+                finishDecoding()
+                return
+            }
+
+            renderer.enqueue(sampleBuffer)
+            framesDecoded += AVAudioFramePosition(buffer.frameLength)
+        }
+    }
+
+    /// Stops media requests and arranges end-of-track notification; runs on decodeQueue
+    private func finishDecoding() {
+        decodingComplete = true
+        renderer.stopRequestingMediaData()
+
+        let endTime = NSValue(time: CMTime(value: framesDecoded, timescale: timescale))
+        endObserver = synchronizer.addBoundaryTimeObserver(forTimes: [endTime], queue: .main) { [weak self] in
+            guard let self = self else { return }
+            self.removeEndObserver()
+            self.delegate?.spatialAudioRendererDidReachEnd(self)
+        }
+    }
+
+    private func removeEndObserver() {
+        if let endObserver {
+            synchronizer.removeTimeObserver(endObserver)
+            self.endObserver = nil
+        }
+    }
+
+    /// Returns an interleaved copy of the buffer when needed; runs on decodeQueue.
+    ///
+    /// `AVSampleBufferAudioRenderer` renders through an AudioQueue, which only
+    /// accepts interleaved linear PCM — non-interleaved buffers (e.g. FLAC decoder
+    /// output or the effects chain's standard format) enqueue without error but
+    /// render as silence ("SSP::Render: CopySlice" failures in the system log).
+    private func interleavedIfNeeded(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard !buffer.format.isInterleaved else { return buffer }
+
+        if interleaveConverter?.inputFormat != buffer.format {
+            guard let outputFormat = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: buffer.format.sampleRate,
+                channels: buffer.format.channelCount,
+                interleaved: true
+            ), let converter = AVAudioConverter(from: buffer.format, to: outputFormat) else {
+                return nil
+            }
+            interleaveConverter = converter
+        }
+
+        // A fresh output buffer per chunk so enqueued sample buffers never share memory
+        guard let converter = interleaveConverter,
+              let output = AVAudioPCMBuffer(pcmFormat: converter.outputFormat, frameCapacity: buffer.frameLength) else {
+            return nil
+        }
+
+        do {
+            try converter.convert(to: output, from: buffer)
+        } catch {
+            Logger.error("Interleave conversion failed: \(error.localizedDescription)")
+            return nil
+        }
+
+        guard output.frameLength == buffer.frameLength else { return nil }
+        return output
+    }
+
+    /// Wraps decoded PCM in a CMSampleBuffer for the renderer
+    private func makeSampleBuffer(from buffer: AVAudioPCMBuffer, presentationTime: CMTime) -> CMSampleBuffer? {
+        var sampleBuffer: CMSampleBuffer?
+        var timing = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: CMTimeScale(buffer.format.sampleRate)),
+            presentationTimeStamp: presentationTime,
+            decodeTimeStamp: .invalid
+        )
+
+        let createStatus = CMSampleBufferCreate(
+            allocator: kCFAllocatorDefault,
+            dataBuffer: nil,
+            dataReady: false,
+            makeDataReadyCallback: nil,
+            refcon: nil,
+            formatDescription: buffer.format.formatDescription,
+            sampleCount: CMItemCount(buffer.frameLength),
+            sampleTimingEntryCount: 1,
+            sampleTimingArray: &timing,
+            sampleSizeEntryCount: 0,
+            sampleSizeArray: nil,
+            sampleBufferOut: &sampleBuffer
+        )
+
+        guard createStatus == noErr, let sampleBuffer else { return nil }
+
+        let fillStatus = CMSampleBufferSetDataBufferFromAudioBufferList(
+            sampleBuffer,
+            blockBufferAllocator: kCFAllocatorDefault,
+            blockBufferMemoryAllocator: kCFAllocatorDefault,
+            flags: kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment,
+            bufferList: buffer.audioBufferList
+        )
+
+        guard fillStatus == noErr else { return nil }
+        return sampleBuffer
+    }
+}


### PR DESCRIPTION
## Summary

Makes Petrichor's audio eligible for **macOS system-level Spatial Audio**: with AirPods (3rd gen)/Pro/Max connected, the Sound menu offers **Spatialize Stereo (Fixed / Head Tracked)** instead of "Spatial Audio: Not Available", and the OS performs all spatialization and head tracking natively. It works out of the box for all playback — no setting, no UI — exactly like Apple Music.

| Before | After |
|---|---|
| "Spatial Audio: Not Available" while Petrichor plays | Spatialize Stereo: Off / Fixed / Head Tracked |

### Why this approach

On macOS, the system spatializer only processes audio rendered through `AVPlayer` / `AVSampleBufferAudioRenderer` (WWDC21 "Immerse your app in Spatial Audio"). Audio from an `AVAudioEngine`/CoreAudio graph — Petrichor's current output — is never eligible, and there's no flag to opt it in (this is also why e.g. Spotify lacks the feature). The approach here is the one kode54 uses in Cog ([Apple dev forums](https://developer.apple.com/forums/thread/706033)): keep SFBAudioEngine as the **decoder** (every supported format still works, pre-buffering for network volumes preserved) and render decoded PCM through `AVSampleBufferAudioRenderer` + `AVSampleBufferRenderSynchronizer` with `allowedAudioSpatializationFormats = .monoStereoAndMultichannel` (macOS 12+, within the 14.0 target).

### Changes (3 files, single commit)

- **`Core/SpatialAudioRenderer.swift`** (new) — output engine: pulls PCM from any SFB `PCMDecoding`, enqueues `CMSampleBuffer`s on a continuous timeline, and handles play/pause/seek/volume/end-of-track via the render synchronizer. PCM is interleaved before enqueueing: the renderer's AudioQueue only accepts interleaved linear PCM and silently renders nothing otherwise (`SSP::Render: CopySlice` failures in the system log)
- **`Core/AudioEffectsChain.swift`** (new) — keeps the in-app **Equalizer, Stereo Widening and preamp fully working**: decoded PCM runs through an offline `AVAudioEngine` chain (the same `AVAudioUnitDelay` Haas effect + 10-band `AVAudioUnitEQ` as today) before enqueueing. Non-Float32/deinterleaved decoder formats are converted on the way in; with no effect enabled, buffers pass through bit-exact
- **`Core/AudioPlayer.swift`** — `PAudioPlayer` drives the new renderer instead of `SFBAudioEngine.AudioPlayer`; public API and delegate semantics are unchanged, so `PlaybackManager` and all views needed zero changes

## Testing

- Build with no warnings (macOS 26.5 SDK, deployment target 14.0)
- Standalone harness linking the real SFBAudioEngine decoders against the exact shipped sources: accurate playback clock, mid-track seek, end-of-track detection, EQ toggled live; FLAC (16-bit-in-4-bytes deinterleaved), MP3 (Float32 deinterleaved) and WAV (Int16 interleaved) all decode and render with zero `CopySlice` errors in the system log
- Effects chain: bit-exact passthrough when disabled; EQ/widening measurably alter the signal when enabled
- **Hardware-confirmed on AirPods Pro**: audio plays normally and the Spatialize Stereo options appear in Control Center while Petrichor plays

Supersedes #292 and #293 (same feature; this branch is the clean, minimal, squashed version).

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)