### PR TITLE
Improve library refresh to be concurrency-safe to prevent crashes

### DIFF
--- a/Core/ArtistParser.swift
+++ b/Core/ArtistParser.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ArtistParser {
+enum ArtistParser {
     // High-confidence separators - always split, never part of an artist name
     private static let highConfidenceSeparators = [
         " feat. ", " feat ", " featuring ", " ft. ", " ft ",
@@ -25,7 +25,7 @@ struct ArtistParser {
     private static let safeSeparators = highConfidenceSeparators + ambiguousSeparators.filter { !unsafeSeparators.contains($0) }
 
     // MARK: - Caching
-    private static let cacheQueue = DispatchQueue(label: "com.petrichor.artistparser.cache", attributes: .concurrent)
+    private static let cacheQueue = DispatchQueue(label: "org.Petrichor.artistparser.cache", attributes: .concurrent)
     private static var parseCache = [String: [String]]()
     private static var normalizeCache = [String: String]()
 
@@ -49,48 +49,80 @@ struct ArtistParser {
 
     // MARK: - Known Artists
 
+    // Concurrent so that reads (`hasKnownArtists`, `isKnownArtist`) run in parallel during
+    // a scan; load/unload mutate state behind a `.barrier` for exclusive access.
+    private static let knownArtistsQueue = DispatchQueue(label: "org.Petrichor.artistparser.knownArtists", attributes: .concurrent)
+
     /// In-memory set of known artist names, loaded on-demand from bundled text file.
     private static var knownArtists = Set<String>()
+    private static var knownArtistsRetainCount = 0
 
     /// Load known artists from the bundled text file into memory.
+    ///
+    /// Reference-counted: each call must be balanced by exactly one `unloadKnownArtists()`.
+    /// Prefer pairing the two with `defer` so a throwing scan can't leak the retain count.
     static func loadKnownArtists() {
-        guard knownArtists.isEmpty else { return }
+        let result = knownArtistsQueue.sync(flags: .barrier) { () -> (loadedCount: Int, fileName: String?, warning: String?) in
+            knownArtistsRetainCount += 1
 
-        guard let url = findKnownArtistsFile() else {
-            Logger.info("No known artists data file found in bundle")
-            return
+            guard knownArtists.isEmpty else { return (0, nil, nil) }
+
+            guard let url = findKnownArtistsFile() else {
+                return (0, nil, "No known artists data file found in bundle")
+            }
+
+            guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+                return (0, nil, "Failed to read known artists file: \(url.lastPathComponent)")
+            }
+
+            knownArtists = Set(
+                content.components(separatedBy: .newlines).lazy
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+            )
+            return (knownArtists.count, url.lastPathComponent, nil)
         }
 
-        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
-            Logger.warning("Failed to read known artists file: \(url.lastPathComponent)")
-            return
+        if result.loadedCount > 0 {
+            clearParseCache()
+            Logger.info("Loaded \(result.loadedCount) known artists from \(result.fileName ?? "bundle")")
+        } else if let warning = result.warning {
+            Logger.warning(warning)
         }
-
-        knownArtists = Set(
-            content.components(separatedBy: .newlines).lazy
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty && !$0.hasPrefix("#") }
-        )
-
-        Logger.info("Loaded \(knownArtists.count) known artists from \(url.lastPathComponent)")
     }
 
     /// Release known artists from memory after scanning completes.
     static func unloadKnownArtists() {
-        guard !knownArtists.isEmpty else { return }
-        let count = knownArtists.count
-        knownArtists.removeAll()
-        Logger.info("Unloaded \(count) known artists from memory")
+        let unloadedCount = knownArtistsQueue.sync(flags: .barrier) { () -> Int in
+            knownArtistsRetainCount = max(knownArtistsRetainCount - 1, 0)
+            guard knownArtistsRetainCount == 0, !knownArtists.isEmpty else { return 0 }
+
+            let count = knownArtists.count
+            knownArtists.removeAll()
+            return count
+        }
+
+        guard unloadedCount > 0 else { return }
+        clearParseCache()
+        Logger.info("Unloaded \(unloadedCount) known artists from memory")
     }
 
     /// Whether known artists data is available for enhanced parsing.
-    private static var hasKnownArtists: Bool { !knownArtists.isEmpty }
+    private static var hasKnownArtists: Bool {
+        knownArtistsQueue.sync { !knownArtists.isEmpty }
+    }
 
     /// Check if a name matches a known artist.
     static func isKnownArtist(_ name: String) -> Bool {
         let normalized = normalizeArtistName(name)
         guard !normalized.isEmpty else { return false }
-        return knownArtists.contains(normalized)
+        return knownArtistsQueue.sync { knownArtists.contains(normalized) }
+    }
+
+    private static func clearParseCache() {
+        cacheQueue.sync(flags: .barrier) {
+            parseCache.removeAll()
+        }
     }
 
     /// Find the known artists data file in the bundle (known_artists_YYYYMMDD.txt).
@@ -106,8 +138,7 @@ struct ArtistParser {
                 $0.lastPathComponent.hasSuffix(".txt") &&
                 $0.lastPathComponent != About.knownArtistsSampleFile
             }
-            .sorted { $0.lastPathComponent > $1.lastPathComponent }
-            .first
+            .max { $0.lastPathComponent < $1.lastPathComponent }
     }
 
     // MARK: - Normalization
@@ -160,7 +191,8 @@ struct ArtistParser {
     /// to preserve artist names containing separators (e.g., "Mumford & Sons").
     /// Otherwise falls back to splitting on all safe separators.
     static func parse(_ artistString: String, unknownPlaceholder: String = "Unknown Artist") -> [String] {
-        let cacheKey = "\(artistString)|\(unknownPlaceholder)"
+        let usingKnownArtists = hasKnownArtists
+        let cacheKey = "\(artistString)|\(unknownPlaceholder)|\(usingKnownArtists ? "known" : "plain")"
 
         if let cached = cacheQueue.sync(execute: { parseCache[cacheKey] }) {
             return cached
@@ -170,7 +202,7 @@ struct ArtistParser {
             return cacheAndReturn([unknownPlaceholder], forKey: cacheKey)
         }
 
-        let activeSeparators = hasKnownArtists ? allSeparators : safeSeparators
+        let activeSeparators = usingKnownArtists ? allSeparators : safeSeparators
 
         // Fast path: no separators at all
         if !containsAnySeparator(artistString, in: activeSeparators) {
@@ -179,7 +211,7 @@ struct ArtistParser {
         }
 
         let result: [String]
-        if hasKnownArtists {
+        if usingKnownArtists {
             result = parseWithKnownArtists(artistString)
         } else {
             result = splitBySeparators([artistString], separators: activeSeparators)

--- a/Core/MetadataExtractor.swift
+++ b/Core/MetadataExtractor.swift
@@ -63,8 +63,7 @@ actor ArtworkCompressionCache {
 
 // MARK: - Metadata Extractor
 
-class MetadataExtractor {
-
+enum MetadataExtractor {
     // MARK: - Public Methods
 
     /// Extract metadata from an audio file using SFBAudioEngine
@@ -157,8 +156,7 @@ class MetadataExtractor {
                 let ext = url.pathExtension
 
                 if AlbumArtFormat.knownFilenames.contains(filename)
-                    && AlbumArtFormat.isSupported(ext)
-                {
+                    && AlbumArtFormat.isSupported(ext) {
                     if let data = try? Data(contentsOf: url) {
                         artworkMap[directory] = ImageUtils.compressImage(from: data, source: url.path) ?? data
                         foundArtworkInCurrentDir = true
@@ -182,7 +180,7 @@ class MetadataExtractor {
         }
         
         // Duration (TimeInterval is a typealias for Double)
-        if let duration = properties.duration {
+        if let duration = properties.duration, duration.isFinite, duration >= 0 {
             metadata.duration = duration
         }
 
@@ -218,22 +216,22 @@ class MetadataExtractor {
         }
 
         // Sample rate
-        if let sampleRate = properties.sampleRate {
+        if let sampleRate = properties.sampleRate, sampleRate > 0 {
             metadata.sampleRate = Int(sampleRate)
         }
 
         // Channels (AVAudioChannelCount, which is UInt32)
-        if let channelCount = properties.channelCount {
+        if let channelCount = properties.channelCount, channelCount > 0 {
             metadata.channels = Int(channelCount)
         }
 
         // Bit depth
-        if let bitDepth = properties.bitDepth {
+        if let bitDepth = properties.bitDepth, bitDepth > 0 {
             metadata.bitDepth = bitDepth
         }
 
         // Bitrate
-        if let bitrate = properties.bitrate {
+        if let bitrate = properties.bitrate, bitrate > 0 {
             metadata.bitrate = Int(bitrate)
         }
 
@@ -368,6 +366,7 @@ class MetadataExtractor {
         }
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     private static func extractExtendedFields(
         from additionalMetadata: [AnyHashable: Any],
         into metadata: inout TrackMetadata
@@ -381,127 +380,108 @@ class MetadataExtractor {
 
             // Label/Publisher
             if metadata.extended.label == nil
-                && (lowercaseKey.contains("label") || lowercaseKey == "tpub")
-            {
+                && (lowercaseKey.contains("label") || lowercaseKey == "tpub") {
                 metadata.extended.label = stringValue
             }
 
             // Publisher
             if metadata.extended.publisher == nil
-                && lowercaseKey.contains("publisher")
-            {
+                && lowercaseKey.contains("publisher") {
                 metadata.extended.publisher = stringValue
             }
 
             // Copyright
             if metadata.extended.copyright == nil
-                && lowercaseKey.contains("copyright")
-            {
+                && lowercaseKey.contains("copyright") {
                 metadata.extended.copyright = stringValue
             }
 
             // Personnel
             if metadata.extended.conductor == nil
                 && (lowercaseKey == "tpe3"
-                    || lowercaseKey.contains("conductor"))
-            {
+                    || lowercaseKey.contains("conductor")) {
                 metadata.extended.conductor = stringValue
             }
             if metadata.extended.remixer == nil
-                && (lowercaseKey == "tpe4" || lowercaseKey.contains("remixer"))
-            {
+                && (lowercaseKey == "tpe4" || lowercaseKey.contains("remixer")) {
                 metadata.extended.remixer = stringValue
             }
             if metadata.extended.producer == nil
-                && (lowercaseKey == "tpro" || lowercaseKey.contains("producer"))
-            {
+                && (lowercaseKey == "tpro" || lowercaseKey.contains("producer")) {
                 metadata.extended.producer = stringValue
             }
             if metadata.extended.engineer == nil
-                && lowercaseKey.contains("engineer")
-            {
+                && lowercaseKey.contains("engineer") {
                 metadata.extended.engineer = stringValue
             }
             if metadata.extended.lyricist == nil
-                && (lowercaseKey == "text" || lowercaseKey.contains("lyricist"))
-            {
+                && (lowercaseKey == "text" || lowercaseKey.contains("lyricist")) {
                 metadata.extended.lyricist = stringValue
             }
 
             // Original artist
             if metadata.extended.originalArtist == nil
                 && (lowercaseKey == "tope"
-                    || lowercaseKey.contains("originalartist"))
-            {
+                    || lowercaseKey.contains("originalartist")) {
                 metadata.extended.originalArtist = stringValue
             }
 
             // Descriptive fields
             if metadata.extended.subtitle == nil
-                && (lowercaseKey.contains("subtitle") || lowercaseKey == "tit3")
-            {
+                && (lowercaseKey.contains("subtitle") || lowercaseKey == "tit3") {
                 metadata.extended.subtitle = stringValue
             }
             if metadata.extended.movement == nil
-                && lowercaseKey.contains("movement")
-            {
+                && lowercaseKey.contains("movement") {
                 metadata.extended.movement = stringValue
             }
             if metadata.extended.key == nil
                 && (lowercaseKey == "tkey"
                     || lowercaseKey.contains("initialkey")
-                    || lowercaseKey.contains("musicalkey"))
-            {
+                    || lowercaseKey.contains("musicalkey")) {
                 metadata.extended.key = stringValue
             }
             if metadata.extended.mood == nil && lowercaseKey.contains("mood") {
                 metadata.extended.mood = stringValue
             }
             if metadata.extended.language == nil
-                && (lowercaseKey == "tlan" || lowercaseKey.contains("language"))
-            {
+                && (lowercaseKey == "tlan" || lowercaseKey.contains("language")) {
                 metadata.extended.language = stringValue
             }
 
             // Identifiers
             if metadata.extended.barcode == nil
                 && (lowercaseKey.contains("barcode")
-                    || lowercaseKey.contains("upc"))
-            {
+                    || lowercaseKey.contains("upc")) {
                 metadata.extended.barcode = stringValue
             }
             if metadata.extended.catalogNumber == nil
-                && lowercaseKey.contains("catalog")
-            {
+                && lowercaseKey.contains("catalog") {
                 metadata.extended.catalogNumber = stringValue
             }
 
             // Encoding
             if metadata.extended.encodedBy == nil
                 && (lowercaseKey == "tenc"
-                    || lowercaseKey.contains("encodedby"))
-            {
+                    || lowercaseKey.contains("encodedby")) {
                 metadata.extended.encodedBy = stringValue
             }
             if metadata.extended.encoderSettings == nil
                 && (lowercaseKey == "tsse"
-                    || lowercaseKey.contains("encodersettings"))
-            {
+                    || lowercaseKey.contains("encodersettings")) {
                 metadata.extended.encoderSettings = stringValue
             }
 
             // Recording date
             if metadata.extended.recordingDate == nil
-                && lowercaseKey.contains("recordingdate")
-            {
+                && lowercaseKey.contains("recordingdate") {
                 metadata.extended.recordingDate = stringValue
             }
 
             // Original release date
             if metadata.originalReleaseDate == nil
                 && (lowercaseKey.contains("originaldate")
-                    || lowercaseKey == "tdor")
-            {
+                    || lowercaseKey == "tdor") {
                 metadata.originalReleaseDate = stringValue
                 // Also try to extract year if not set
                 if metadata.year == nil {
@@ -516,48 +496,41 @@ class MetadataExtractor {
             if metadata.extended.musicBrainzArtistId == nil
                 && lowercaseKey.contains("musicbrainz")
                 && lowercaseKey.contains("artist")
-                && lowercaseKey.contains("id")
-            {
+                && lowercaseKey.contains("id") {
                 metadata.extended.musicBrainzArtistId = stringValue
             }
             if metadata.extended.musicBrainzAlbumArtistId == nil
                 && lowercaseKey.contains("musicbrainz")
                 && lowercaseKey.contains("albumartist")
-                && lowercaseKey.contains("id")
-            {
+                && lowercaseKey.contains("id") {
                 metadata.extended.musicBrainzAlbumArtistId = stringValue
             }
             if metadata.extended.musicBrainzReleaseGroupId == nil
                 && lowercaseKey.contains("musicbrainz")
-                && lowercaseKey.contains("releasegroup")
-            {
+                && lowercaseKey.contains("releasegroup") {
                 metadata.extended.musicBrainzReleaseGroupId = stringValue
             }
             if metadata.extended.musicBrainzWorkId == nil
                 && lowercaseKey.contains("musicbrainz")
-                && lowercaseKey.contains("work") && lowercaseKey.contains("id")
-            {
+                && lowercaseKey.contains("work") && lowercaseKey.contains("id") {
                 metadata.extended.musicBrainzWorkId = stringValue
             }
 
             // AcoustID
             if metadata.extended.acoustId == nil
                 && lowercaseKey.contains("acoustid")
-                && !lowercaseKey.contains("fingerprint")
-            {
+                && !lowercaseKey.contains("fingerprint") {
                 metadata.extended.acoustId = stringValue
             }
             if metadata.extended.acoustIdFingerprint == nil
                 && lowercaseKey.contains("acoustid")
-                && lowercaseKey.contains("fingerprint")
-            {
+                && lowercaseKey.contains("fingerprint") {
                 metadata.extended.acoustIdFingerprint = stringValue
             }
 
             // Composer sort order (not in standard AudioMetadata)
             if metadata.extended.sortComposer == nil
-                && lowercaseKey.contains("composersort")
-            {
+                && lowercaseKey.contains("composersort") {
                 metadata.extended.sortComposer = stringValue
             }
         }
@@ -604,14 +577,11 @@ class MetadataExtractor {
         let yearPattern = #"\b(19|20)\d{2}\b"#
 
         if let regex = try? NSRegularExpression(pattern: yearPattern),
-            let match = regex.firstMatch(
-                in: dateString,
-                range: NSRange(dateString.startIndex..., in: dateString)
-            )
-        {
-            if let range = Range(match.range, in: dateString) {
-                return String(dateString[range])
-            }
+           let match = regex.firstMatch(
+            in: dateString,
+            range: NSRange(dateString.startIndex..., in: dateString)
+           ) {
+            if let range = Range(match.range, in: dateString) { return String(dateString[range]) }
         }
 
         return ""

--- a/Managers/Database/DMBackgroundMigration.swift
+++ b/Managers/Database/DMBackgroundMigration.swift
@@ -336,6 +336,8 @@ extension DatabaseManager {
             let pinnedAlbums = self.snapshotPinnedItems(idColumn: PinnedItem.Columns.albumId)
 
             ArtistParser.loadKnownArtists()
+            // Balanced unload even if a batch write below throws, so the retain count can't leak.
+            defer { ArtistParser.unloadKnownArtists() }
 
             // Clear existing associations and reset stats
             _ = try dbQueue.write { db in
@@ -383,7 +385,6 @@ extension DatabaseManager {
             self.relinkPinnedArtists(pinnedArtists)
             self.relinkPinnedAlbums(pinnedAlbums)
 
-            ArtistParser.unloadKnownArtists()
             Logger.info("Artist associations rebuild completed")
         }.value
 

--- a/Managers/Database/DMCleanup.swift
+++ b/Managers/Database/DMCleanup.swift
@@ -158,7 +158,7 @@ extension DatabaseManager {
     }
     
     //// Clean up after removing specific tracks
-    func cleanupAfterTrackRemoval(_ trackIds: [UUID]) async throws {
+    func cleanupAfterTrackRemoval(_ trackIds: [Int64]) async throws {
         guard !trackIds.isEmpty else { return }
         
         Logger.info("Cleaning up after removing \(trackIds.count) tracks...")
@@ -166,13 +166,13 @@ extension DatabaseManager {
         try await dbQueue.write { db in
             // Get affected artist and album IDs before deletion
             let affectedArtistIds = try TrackArtist
-                .filter(trackIds.map { $0.uuidString }.contains(TrackArtist.Columns.trackId))
+                .filter(trackIds.contains(TrackArtist.Columns.trackId))
                 .select(TrackArtist.Columns.artistId, as: Int64.self)
                 .distinct()
                 .fetchSet(db)
             
             let affectedAlbumIds = try Track
-                .filter(trackIds.map { $0.uuidString }.contains(Track.Columns.trackId))
+                .filter(trackIds.contains(Track.Columns.trackId))
                 .filter(Track.Columns.albumId != nil)
                 .select(Track.Columns.albumId, as: Int64?.self)
                 .fetchSet(db)
@@ -180,18 +180,16 @@ extension DatabaseManager {
             
             // Get affected genre IDs
             let affectedGenreIds = try TrackGenre
-                .filter(trackIds.map { $0.uuidString }.contains(TrackGenre.Columns.trackId))
+                .filter(trackIds.contains(TrackGenre.Columns.trackId))
                 .select(TrackGenre.Columns.genreId, as: Int64.self)
                 .distinct()
                 .fetchSet(db)
             
             // Now check if these artists/albums/genres still have other tracks
-            let trackIdStrings = trackIds.map { $0.uuidString }
-            
             // Artists that still have tracks
             let artistsWithTracks = try TrackArtist
                 .filter(affectedArtistIds.contains(TrackArtist.Columns.artistId))
-                .filter(!trackIdStrings.contains(TrackArtist.Columns.trackId))
+                .filter(!trackIds.contains(TrackArtist.Columns.trackId))
                 .select(TrackArtist.Columns.artistId, as: Int64.self)
                 .distinct()
                 .fetchSet(db)
@@ -208,7 +206,7 @@ extension DatabaseManager {
             // Albums that still have tracks
             let albumsWithTracks = try Track
                 .filter(affectedAlbumIds.contains(Track.Columns.albumId))
-                .filter(!trackIdStrings.contains(Track.Columns.trackId))
+                .filter(!trackIds.contains(Track.Columns.trackId))
                 .select(Track.Columns.albumId, as: Int64?.self)
                 .distinct()
                 .fetchSet(db)
@@ -226,7 +224,7 @@ extension DatabaseManager {
             // Genres that still have tracks
             let genresWithTracks = try TrackGenre
                 .filter(affectedGenreIds.contains(TrackGenre.Columns.genreId))
-                .filter(!trackIdStrings.contains(TrackGenre.Columns.trackId))
+                .filter(!trackIds.contains(TrackGenre.Columns.trackId))
                 .select(TrackGenre.Columns.genreId, as: Int64.self)
                 .distinct()
                 .fetchSet(db)

--- a/Managers/Database/DMFolders.swift
+++ b/Managers/Database/DMFolders.swift
@@ -30,11 +30,20 @@ actor ScanState {
     func getSkippedFiles() -> [(url: URL, extension: String)] { skippedFiles }
 }
 
+struct GlobalScanProgress {
+    let processed: Int
+    let total: Int
+    let added: Int
+    let removed: Int
+    let isInitial: Bool
+}
+
 actor GlobalScanState {
     let totalFiles: Int
     let isInitialScan: Bool
     var processedFiles = 0
-    var tracksFound = 0
+    var tracksAdded = 0
+    var tracksRemoved = 0
     
     init(totalFiles: Int, isInitialScan: Bool = false) {
         self.totalFiles = totalFiles
@@ -45,12 +54,22 @@ actor GlobalScanState {
         processedFiles += count
     }
     
-    func incrementTracksFound(by count: Int) {
-        tracksFound += count
+    func incrementTracksAdded(by count: Int) {
+        tracksAdded += count
     }
-    
-    func getProgress() -> (processed: Int, total: Int, tracks: Int, isInitial: Bool) {
-        (processedFiles, totalFiles, tracksFound, isInitialScan)
+
+    func incrementTracksRemoved(by count: Int) {
+        tracksRemoved += count
+    }
+
+    func getProgress() -> GlobalScanProgress {
+        GlobalScanProgress(
+            processed: processedFiles,
+            total: totalFiles,
+            added: tracksAdded,
+            removed: tracksRemoved,
+            isInitial: isInitialScan
+        )
     }
 }
 
@@ -178,13 +197,21 @@ extension DatabaseManager {
         }
     }
 
-    func refreshFolder(_ folder: Folder, hardRefresh: Bool = false, _ completion: @escaping (Result<Void, Error>) -> Void) {
+    func refreshFolder(
+        _ folder: Folder,
+        hardRefresh: Bool = false,
+        manageActivityIndicator: Bool = true,
+        globalScanState: GlobalScanState? = nil,
+        _ completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         Task {
             do {
                 await MainActor.run {
                     self.isScanning = true
                     self.scanStatusMessage = "Refreshing \(folder.name)..."
-                    NotificationManager.shared.startActivity("Refreshing \(folder.name)...")
+                    if manageActivityIndicator {
+                        NotificationManager.shared.startActivity("Refreshing \(folder.name)...")
+                    }
                 }
 
                 // Log the current state
@@ -192,9 +219,17 @@ extension DatabaseManager {
                 Logger.info("Starting refresh for folder \(folder.name) with \(trackCountBefore) tracks")
 
                 ArtistParser.loadKnownArtists()
+                // Balanced unload on every exit path (success or throw) so the retain count
+                // can't leak or double-decrement a concurrent scan's data.
+                defer { ArtistParser.unloadKnownArtists() }
 
                 // Scan the folder - this will check for metadata updates
-                try await scanSingleFolder(folder, supportedExtensions: AudioFormat.supportedExtensions, hardRefresh: hardRefresh)
+                try await scanSingleFolder(
+                    folder,
+                    supportedExtensions: AudioFormat.supportedExtensions,
+                    hardRefresh: hardRefresh,
+                    globalScanState: globalScanState
+                )
 
                 // Update folder's metadata
                 if let folderId = folder.id {
@@ -204,8 +239,6 @@ extension DatabaseManager {
                 // Log the result
                 let trackCountAfter = getTracksForFolder(folder.id ?? -1).count
                 Logger.info("Completed refresh for folder \(folder.name) with \(trackCountAfter) tracks (was \(trackCountBefore))")
-
-                ArtistParser.unloadKnownArtists()
 
                 // Post-scan: normalize compilation albums, update stats, detect duplicates, and clean up
                 try await normalizeCompilationAlbums()
@@ -218,16 +251,18 @@ extension DatabaseManager {
                 await MainActor.run {
                     self.isScanning = false
                     self.scanStatusMessage = ""
-                    NotificationManager.shared.stopActivity()
+                    if manageActivityIndicator {
+                        NotificationManager.shared.stopActivity()
+                    }
                     completion(.success(()))
                 }
             } catch {
-                ArtistParser.unloadKnownArtists()
-
                 await MainActor.run {
                     self.isScanning = false
                     self.scanStatusMessage = ""
-                    NotificationManager.shared.stopActivity()
+                    if manageActivityIndicator {
+                        NotificationManager.shared.stopActivity()
+                    }
                     completion(.failure(error))
                     Logger.error("Failed to refresh folder \(folder.name): \(error)")
                     NotificationManager.shared.addMessage(.error, "Failed to refresh folder \(folder.name)")
@@ -316,7 +351,7 @@ extension DatabaseManager {
         return getTracksForFolder(folderId)
     }
     
-    private func countFilesInFolder(_ folder: Folder, supportedExtensions: [String]) async -> Int {
+    func countFilesInFolder(_ folder: Folder, supportedExtensions: [String]) async -> Int {
         guard let enumerator = FileManager.default.enumerator(
             at: folder.url,
             includingPropertiesForKeys: [.isRegularFileKey],
@@ -361,6 +396,8 @@ extension DatabaseManager {
         let globalScanState = GlobalScanState(totalFiles: totalFiles, isInitialScan: isInitialScan)
         
         ArtistParser.loadKnownArtists()
+        // Balanced unload on every exit path, including a throw from the post-scan steps below.
+        defer { ArtistParser.unloadKnownArtists() }
 
         var processedFolders = 0
 
@@ -379,12 +416,10 @@ extension DatabaseManager {
                 }
             }
             
-            if processedFolders % 2 == 0 {
+            if processedFolders.isMultiple(of: 2) {
                 await Task.yield()
             }
         }
-
-        ArtistParser.unloadKnownArtists()
 
         // Post-scan: normalize compilation albums, update stats, detect duplicates, and clean up once for all folders
         try await normalizeCompilationAlbums()
@@ -465,7 +500,8 @@ extension DatabaseManager {
                 folderId: folderId,
                 foundPaths: Set(musicFiles),
                 folderName: folder.name,
-                hasRemainingFiles: !musicFiles.isEmpty
+                hasRemainingFiles: !musicFiles.isEmpty,
+                globalScanState: globalScanState
             )
         }
 
@@ -566,16 +602,30 @@ extension DatabaseManager {
         folderId: Int64,
         foundPaths: Set<URL>,
         folderName: String,
-        hasRemainingFiles: Bool
+        hasRemainingFiles: Bool,
+        globalScanState: GlobalScanState? = nil
     ) async throws {
         let existingTracks = getTracksForFolder(folderId)
         let foundPathStrings = Set(foundPaths.map { $0.path })
         let tracksToRemove = existingTracks.filter { !foundPathStrings.contains($0.url.path) }
-        let trackIdsToRemove = tracksToRemove.compactMap { $0.id }
+        let trackIdsToRemove = tracksToRemove.compactMap { $0.trackId }
         
         guard !trackIdsToRemove.isEmpty else { return }
         
         let removedCount = trackIdsToRemove.count
+
+        await globalScanState?.incrementTracksRemoved(by: removedCount)
+        if let globalScanState {
+            let progress = await globalScanState.getProgress()
+            let detail = scanProgressDetail(progress)
+            await MainActor.run {
+                NotificationManager.shared.updateActivityProgress(
+                    current: progress.processed,
+                    total: progress.total > 0 ? progress.total : progress.processed,
+                    detail: detail
+                )
+            }
+        }
         
         // Remove tracks from database
         try await dbQueue.write { db in
@@ -599,6 +649,24 @@ extension DatabaseManager {
                 NotificationManager.shared.addMessage(.info, message)
             }
         }
+    }
+
+    func scanProgressDetail(_ progress: GlobalScanProgress) -> String {
+        let base = progress.total > 0
+            ? "\(progress.processed) of \(progress.total) files processed"
+            : "\(progress.processed) files processed"
+
+        var changes: [String] = []
+        if progress.added > 0 {
+            let label = progress.isInitial ? "tracks found" : "new tracks found"
+            changes.append("\(progress.added) \(label)")
+        }
+        if progress.removed > 0 {
+            changes.append("\(progress.removed) tracks removed")
+        }
+
+        guard !changes.isEmpty else { return base }
+        return base + " • " + changes.joined(separator: " • ")
     }
 
     private func processMusicFilesInBatches(

--- a/Managers/Database/DMMetadata.swift
+++ b/Managers/Database/DMMetadata.swift
@@ -17,7 +17,7 @@ extension DatabaseManager {
         track.genre = metadata.genre?.nilIfEmpty ?? "Unknown Genre"
         track.composer = metadata.composer?.nilIfEmpty ?? "Unknown Composer"
         track.year = metadata.year?.nilIfEmpty ?? ""
-        track.duration = metadata.duration
+        track.duration = HelperUtils.sanitizedDuration(metadata.duration)
         
         // Avoid storing album art in track table for tracks with albums
         // as we'll store it in albums table instead.
@@ -127,8 +127,9 @@ extension DatabaseManager {
             hasChanges = true
         }
 
-        if metadata.duration > 0 && abs(metadata.duration - track.duration) > 0.1 {
-            track.duration = metadata.duration
+        let newDuration = HelperUtils.sanitizedDuration(metadata.duration)
+        if newDuration > 0 && abs(newDuration - track.duration) > 0.1 {
+            track.duration = newDuration
             hasChanges = true
         }
 

--- a/Managers/Database/DMTrackProcessing.swift
+++ b/Managers/Database/DMTrackProcessing.swift
@@ -134,28 +134,26 @@ extension DatabaseManager {
                 
                 if let globalState = globalScanState {
                     await globalState.incrementProcessed(by: chunkProcessed)
-                    await globalState.incrementTracksFound(by: newTracksCount)
-                    let (globalProcessed, globalTotal, tracksFound, isInitial) = await globalState.getProgress()
+                    await globalState.incrementTracksAdded(by: newTracksCount)
+                    let progress = await globalState.getProgress()
                     
-                    if globalTotal > 0 {
-                        updateScanStatus("Processing: \(globalProcessed)/\(globalTotal) files")
+                    if progress.total > 0 {
+                        updateScanStatus("Processing: \(progress.processed)/\(progress.total) files")
                     } else {
-                        updateScanStatus("Processing: \(globalProcessed) files")
+                        updateScanStatus("Processing: \(progress.processed) files")
                     }
 
                     await MainActor.run {
                         // Update NotificationManager with progress
-                        let detail = globalTotal > 0
-                            ? "\(globalProcessed) of \(globalTotal) files • \(tracksFound) tracks found"
-                            : "\(globalProcessed) files processed • \(tracksFound) tracks found"
+                        let detail = self.scanProgressDetail(progress)
                         NotificationManager.shared.updateActivityProgress(
-                            current: globalProcessed,
-                            total: globalTotal > 0 ? globalTotal : globalProcessed,
+                            current: progress.processed,
+                            total: progress.total > 0 ? progress.total : progress.processed,
                             detail: detail
                         )
                         
                         // Check threshold during initial scan
-                        if isInitial {
+                        if progress.isInitial {
                             NotificationCenter.default.post(name: .checkInitialScanThreshold, object: nil)
                         }
                     }

--- a/Managers/Library/LMLibrary.swift
+++ b/Managers/Library/LMLibrary.swift
@@ -212,12 +212,41 @@ extension LibraryManager {
                 NotificationManager.shared.startActivity("Refreshing \(foldersToRefresh.count) folder\(foldersToRefresh.count == 1 ? "" : "s")...")
             }
 
+            let isSlowFS = foldersToRefresh.first.map { FilesystemUtils.isSlowFilesystem(url: $0.url) } ?? false
+            let totalFiles: Int
+            if isSlowFS {
+                totalFiles = 0
+            } else {
+                var countedFiles = 0
+                for folder in foldersToRefresh {
+                    countedFiles += await databaseManager.countFilesInFolder(
+                        folder,
+                        supportedExtensions: AudioFormat.supportedExtensions
+                    )
+                }
+                totalFiles = countedFiles
+            }
+            let globalScanState = GlobalScanState(totalFiles: totalFiles)
+
+            await MainActor.run {
+                NotificationManager.shared.updateActivityProgress(
+                    current: 0,
+                    total: totalFiles,
+                    detail: totalFiles > 0 ? "0 of \(totalFiles) files" : "Preparing files..."
+                )
+            }
+
             // Process folders
             for folder in foldersToRefresh {
                 group.enter()
                 
                 await MainActor.run { [weak self] in
-                    self?.databaseManager.refreshFolder(folder, hardRefresh: hardRefresh) { result in
+                    self?.databaseManager.refreshFolder(
+                        folder,
+                        hardRefresh: hardRefresh,
+                        manageActivityIndicator: false,
+                        globalScanState: globalScanState
+                    ) { result in
                         Task {
                             switch result {
                             case .success:

--- a/Models/Core/FullTrack.swift
+++ b/Models/Core/FullTrack.swift
@@ -169,7 +169,8 @@ struct FullTrack: Identifiable, Equatable, Hashable, FetchableRecord, Persistabl
         composer = row[Columns.composer]
         genre = row[Columns.genre]
         year = row[Columns.year]
-        duration = row[Columns.duration]
+        let storedDuration: Double = row[Columns.duration]
+        duration = HelperUtils.sanitizedDuration(storedDuration)
         trackArtworkData = row[Columns.trackArtworkData]
         dateAdded = row[Columns.dateAdded]
         isFavorite = row[Columns.isFavorite]
@@ -324,7 +325,8 @@ struct FullTrack: Identifiable, Equatable, Hashable, FetchableRecord, Persistabl
         let normalizedYear = year.trimmingCharacters(in: .whitespacesAndNewlines)
         
         // Round duration to nearest 2 seconds to handle slight variations
-        let roundedDuration = Int((duration / 2.0).rounded()) * 2
+        let safeDuration = HelperUtils.sanitizedDuration(duration)
+        let roundedDuration = Int((safeDuration / 2.0).rounded()) * 2
         
         return "\(normalizedTitle)|\(normalizedArtist)|\(normalizedAlbum)|\(normalizedYear)|\(roundedDuration)"
     }
@@ -362,10 +364,8 @@ extension FullTrack {
             "dsd", "dsf", "dff"
         ]
         
-        for losslessCodec in losslessCodecs {
-            if codecLower.contains(losslessCodec) {
-                return true
-            }
+        for losslessCodec in losslessCodecs where codecLower.contains(losslessCodec) {
+            return true
         }
         
         let losslessFormats: Set<String> = [

--- a/Models/Core/Playlist.swift
+++ b/Models/Core/Playlist.swift
@@ -275,6 +275,10 @@ struct Playlist: Identifiable, FetchableRecord, PersistableRecord {
     var totalDuration: Double {
         tracks.reduce(0) { $0 + $1.duration }
     }
+
+    var formattedTotalDuration: String {
+        HelperUtils.formattedDuration(totalDuration)
+    }
     
     var artworkData: Data? {
         if let customCover = coverArtworkData {
@@ -389,23 +393,6 @@ struct Playlist: Identifiable, FetchableRecord, PersistableRecord {
         #else
         return ImageUtils.encodeHEIC(collageImage)
         #endif
-    }
-}
-
-// Extension to format the duration for display
-extension Playlist {
-    // Format the total duration as a string (HH:MM:SS)
-    var formattedTotalDuration: String {
-        let totalSeconds = Int(totalDuration)
-        let hours = totalSeconds / 3600
-        let minutes = (totalSeconds % 3600) / 60
-        let seconds = totalSeconds % 60
-        
-        if hours > 0 {
-            return String(format: StringFormat.hhmmss, hours, minutes, seconds)
-        } else {
-            return String(format: StringFormat.mmss, minutes, seconds)
-        }
     }
 }
 

--- a/Models/Core/Track.swift
+++ b/Models/Core/Track.swift
@@ -130,7 +130,8 @@ struct Track: Identifiable, Equatable, Hashable, FetchableRecord, PersistableRec
         composer = row[Columns.composer]
         genre = row[Columns.genre]
         year = row[Columns.year]
-        duration = row[Columns.duration]
+        let storedDuration: Double = row[Columns.duration]
+        duration = HelperUtils.sanitizedDuration(storedDuration)
         lossless = row[Columns.lossless]
         dateAdded = row[Columns.dateAdded]
         isFavorite = row[Columns.isFavorite]
@@ -210,16 +211,7 @@ extension Track {
     
     /// Get formatted duration string
     var formattedDuration: String {
-        let totalSeconds = Int(duration)
-        let hours = totalSeconds / 3600
-        let minutes = (totalSeconds % 3600) / 60
-        let seconds = totalSeconds % 60
-        
-        if hours > 0 {
-            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
-        } else {
-            return String(format: "%d:%02d", minutes, seconds)
-        }
+        HelperUtils.formattedDuration(duration)
     }
     
     /// Computed property for artwork
@@ -302,7 +294,8 @@ extension Track {
         let normalizedYear = year.trimmingCharacters(in: .whitespacesAndNewlines)
         
         // Round duration to nearest 2 seconds to handle slight variations
-        let roundedDuration = Int((duration / 2.0).rounded()) * 2
+        let safeDuration = HelperUtils.sanitizedDuration(duration)
+        let roundedDuration = Int((safeDuration / 2.0).rounded()) * 2
         
         return "\(normalizedTitle)|\(normalizedArtist)|\(normalizedAlbum)|\(normalizedYear)|\(roundedDuration)"
     }

--- a/Utilities/DiagnosticSnapshot.swift
+++ b/Utilities/DiagnosticSnapshot.swift
@@ -51,7 +51,7 @@ enum DiagnosticSnapshot {
             library["albumCount"] = lm.albumCount
             library["playlistCount"] = coordinator.playlistManager.playlists.count
             library["pinnedItemCount"] = lm.pinnedItems.count
-            library["totalDurationSec"] = duration.isFinite ? Int(duration) : 0
+            library["totalDurationSec"] = HelperUtils.sanitizedWholeDuration(duration)
             library["totalSize"] = bytes(db.getTotalFileSize())
             library["formats"] = db.getTrackCountsByFormat()
             library["folders"] = lm.folders.map { ($0.url.path as NSString).abbreviatingWithTildeInPath }

--- a/Utilities/HelperUtils.swift
+++ b/Utilities/HelperUtils.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+enum HelperUtils {
+    /// Sanitizes a duration value for safe display, persistence, and numeric conversion.
+    /// Converts negative, NaN, and infinite values to zero.
+    /// - Parameter seconds: Duration in seconds.
+    /// - Returns: A finite, non-negative duration in seconds.
+    static func sanitizedDuration(_ seconds: Double) -> Double {
+        seconds.isFinite && seconds >= 0 ? seconds : 0
+    }
+
+    /// Sanitizes a duration and converts it to whole seconds.
+    /// This method is safe to call before `Int` conversion because invalid values are normalized first.
+    /// - Parameter seconds: Duration in seconds.
+    /// - Returns: A finite, non-negative duration rounded toward zero as whole seconds.
+    static func sanitizedWholeDuration(_ seconds: Double) -> Int {
+        Int(sanitizedDuration(seconds))
+    }
+
+    /// Formats a duration for display, using hours when needed.
+    /// Invalid values such as NaN, infinity, and negative durations are displayed as zero.
+    /// - Parameter seconds: Duration in seconds.
+    /// - Returns: A formatted duration string (`H:MM:SS` when hours are present, otherwise `M:SS`).
+    static func formattedDuration(_ seconds: Double) -> String {
+        let totalSeconds = sanitizedWholeDuration(seconds)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let remainingSeconds = totalSeconds % 60
+
+        if hours > 0 {
+            return String(format: StringFormat.hhmmss, hours, minutes, remainingSeconds)
+        }
+        return String(format: StringFormat.mmss, minutes, remainingSeconds)
+    }
+
+    /// Formats a duration for compact display without an hours component.
+    /// Invalid values such as NaN, infinity, and negative durations are displayed as zero.
+    /// - Parameter seconds: Duration in seconds.
+    /// - Returns: A formatted duration string (`M:SS`).
+    static func formattedShortDuration(_ seconds: Double) -> String {
+        let totalSeconds = sanitizedWholeDuration(seconds)
+        let minutes = totalSeconds / 60
+        let remainingSeconds = totalSeconds % 60
+        return String(format: StringFormat.mmss, minutes, remainingSeconds)
+    }
+
+    /// Formats a duration as a compact textual summary for stats labels.
+    /// Invalid values such as NaN, infinity, and negative durations are displayed as zero.
+    /// - Parameter seconds: Duration in seconds.
+    /// - Returns: A formatted duration string (`H hr M min` when hours are present, otherwise `M min`).
+    static func formattedDurationSummary(_ seconds: Double) -> String {
+        let totalSeconds = sanitizedWholeDuration(seconds)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+
+        if hours > 0 {
+            return "\(hours) hr \(minutes) min"
+        }
+        return "\(minutes) min"
+    }
+}

--- a/Views/Components/TrackViews/TrackTableView.swift
+++ b/Views/Components/TrackViews/TrackTableView.swift
@@ -293,7 +293,7 @@ struct TrackTableView: View {
                 
                 // Duration
                 TableColumn("Duration", value: \.duration) { track in
-                    Text(formatDuration(track.duration))
+                    Text(HelperUtils.formattedShortDuration(track.duration))
                         .font(isCurrentTrack(track) ? Self.currentTrackFont : Self.trackFont)
                         .foregroundColor(.secondary)
                         .monospacedDigit()
@@ -358,13 +358,6 @@ struct TrackTableView: View {
         } else {
             playlistManager.currentQueueSource = .library
         }
-    }
-    
-    private func formatDuration(_ seconds: Double) -> String {
-        let totalSeconds = Int(max(0, seconds))
-        let minutes = totalSeconds / 60
-        let remainingSeconds = totalSeconds % 60
-        return String(format: StringFormat.mmss, minutes, remainingSeconds)
     }
     
     private static let dateFormatter: DateFormatter = {

--- a/Views/Components/Widgets/NotificationTray.swift
+++ b/Views/Components/Widgets/NotificationTray.swift
@@ -70,13 +70,30 @@ class NotificationManager: ObservableObject {
     // MARK: - Activity Management
     
     func startActivity(_ message: String) {
+        guard !Thread.isMainThread else {
+            isActivityInProgress = true
+            activityMessage = message
+            activityProgress = nil
+            lastProgressUpdateTime = .distantPast
+            return
+        }
+
         DispatchQueue.main.async {
             self.isActivityInProgress = true
             self.activityMessage = message
+            self.activityProgress = nil
+            self.lastProgressUpdateTime = .distantPast
         }
     }
     
     func stopActivity() {
+        guard !Thread.isMainThread else {
+            isActivityInProgress = false
+            activityMessage = ""
+            activityProgress = nil
+            return
+        }
+
         DispatchQueue.main.async {
             self.isActivityInProgress = false
             self.activityMessage = ""

--- a/Views/Home/EntityDetailView.swift
+++ b/Views/Home/EntityDetailView.swift
@@ -339,7 +339,7 @@ struct EntityDetailView: View {
             statText("\(tracks.count) \(tracks.count == 1 ? "song" : "songs")")
             if !tracks.isEmpty {
                 statDot
-                statText(formattedTotalDuration)
+                statText(HelperUtils.formattedDurationSummary(totalTrackDuration))
                 trailing()
             }
         }
@@ -439,17 +439,8 @@ struct EntityDetailView: View {
     
     // MARK: - Computed Properties
     
-    private var formattedTotalDuration: String {
-        let totalSeconds = tracks.reduce(0) { $0 + $1.duration }
-        
-        let hours = Int(totalSeconds) / 3600
-        let minutes = (Int(totalSeconds) % 3600) / 60
-        
-        if hours > 0 {
-            return "\(hours) hr \(minutes) min"
-        } else {
-            return "\(minutes) min"
-        }
+    private var totalTrackDuration: Double {
+        tracks.reduce(0) { $0 + HelperUtils.sanitizedDuration($1.duration) }
     }
     
     private var isAlbumFullyLossless: Bool {

--- a/Views/Main/PlayQueueView.swift
+++ b/Views/Main/PlayQueueView.swift
@@ -213,7 +213,7 @@ struct PlayQueueRow: View {
 
     private var trackControls: some View {
         HStack(spacing: 5) {
-            Text(formatDuration(track.duration))
+            Text(HelperUtils.formattedShortDuration(track.duration))
                 .font(.system(size: 11))
                 .foregroundColor(isCurrentTrack ? .white : .secondary)
                 .monospacedDigit()
@@ -248,12 +248,6 @@ struct PlayQueueRow: View {
             }
         }
         .cornerRadius(6)
-    }
-
-    private func formatDuration(_ seconds: Double) -> String {
-        let minutes = Int(seconds) / 60
-        let remainingSeconds = Int(seconds) % 60
-        return String(format: StringFormat.mmss, minutes, remainingSeconds)
     }
 
     private func handleDoubleClick() {

--- a/Views/Main/PlayerView.swift
+++ b/Views/Main/PlayerView.swift
@@ -247,7 +247,7 @@ struct PlayerView: View {
     private var progressBar: some View {
         HStack(spacing: 8) {
             // Current time - updated to use displayTime
-            Text(formatDuration(isDraggingProgress ? tempProgressValue : playbackManager.currentTime))
+            Text(HelperUtils.formattedShortDuration(isDraggingProgress ? tempProgressValue : playbackManager.currentTime))
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(.secondary)
                 .monospacedDigit()
@@ -257,7 +257,7 @@ struct PlayerView: View {
             progressSlider
 
             // Total duration
-            Text(formatDuration(playbackManager.currentTrack?.duration ?? 0))
+            Text(HelperUtils.formattedShortDuration(playbackManager.currentTrack?.duration ?? 0))
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(.secondary)
                 .monospacedDigit()
@@ -484,11 +484,13 @@ struct PlayerView: View {
                     isDraggingProgress = true
                 }
                 let percentage = max(0, min(1, value.location.x / geometry.size.width))
-                tempProgressValue = percentage * (playbackManager.currentTrack?.duration ?? 0)
+                let duration = HelperUtils.sanitizedDuration(playbackManager.currentTrack?.duration ?? 0)
+                tempProgressValue = percentage * duration
             }
             .onEnded { value in
                 let percentage = max(0, min(1, value.location.x / geometry.size.width))
-                let newTime = percentage * (playbackManager.currentTrack?.duration ?? 0)
+                let duration = HelperUtils.sanitizedDuration(playbackManager.currentTrack?.duration ?? 0)
+                let newTime = percentage * duration
                 playbackManager.seekTo(time: newTime)
                 // Reset dragging state after seek completes
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -499,15 +501,9 @@ struct PlayerView: View {
 
     private func handleProgressTap(at x: CGFloat, in width: CGFloat) {
         let percentage = x / width
-        let newTime = percentage * (playbackManager.currentTrack?.duration ?? 0)
+        let duration = HelperUtils.sanitizedDuration(playbackManager.currentTrack?.duration ?? 0)
+        let newTime = percentage * duration
         playbackManager.seekTo(time: newTime)
-    }
-
-    private func formatDuration(_ seconds: Double) -> String {
-        let totalSeconds = Int(max(0, seconds))
-        let minutes = totalSeconds / 60
-        let remainingSeconds = totalSeconds % 60
-        return String(format: StringFormat.mmss, minutes, remainingSeconds)
     }
 
     private func toggleMute() {

--- a/Views/Main/TrackDetailView.swift
+++ b/Views/Main/TrackDetailView.swift
@@ -280,7 +280,7 @@ struct TrackDetailView: View {
         }
 
         // Duration
-        items.append(("Duration", formatDuration(fullTrack.duration)))
+        items.append(("Duration", HelperUtils.formattedShortDuration(fullTrack.duration)))
 
         // Track Number
         if let trackNumber = fullTrack.trackNumber {
@@ -381,13 +381,6 @@ struct TrackDetailView: View {
     }
 
     // MARK: - Helper Methods
-
-    private func formatDuration(_ seconds: Double) -> String {
-        let totalSeconds = Int(max(0, seconds))
-        let minutes = totalSeconds / 60
-        let remainingSeconds = totalSeconds % 60
-        return String(format: StringFormat.mmss, minutes, remainingSeconds)
-    }
 
     private func formatDate(_ date: Date) -> String {
         let formatter = DateFormatter()

--- a/Views/Playlists/Sheets/AddSongsToPlaylistSheet.swift
+++ b/Views/Playlists/Sheets/AddSongsToPlaylistSheet.swift
@@ -657,7 +657,7 @@ struct TrackSelectionRow: View {
                 }
 
                 // Duration
-                Text(formatDuration(track.duration))
+                Text(HelperUtils.formattedShortDuration(track.duration))
                     .font(.system(size: 11))
                     .foregroundColor(.secondary)
                     .monospacedDigit()
@@ -702,12 +702,6 @@ struct TrackSelectionRow: View {
         } else {
             return Color.clear
         }
-    }
-
-    private func formatDuration(_ seconds: Double) -> String {
-        let minutes = Int(seconds) / 60
-        let seconds = Int(seconds) % 60
-        return String(format: StringFormat.mmss, minutes, seconds)
     }
 }
 

--- a/Views/Playlists/Sheets/ReorderTracksSheet.swift
+++ b/Views/Playlists/Sheets/ReorderTracksSheet.swift
@@ -176,18 +176,12 @@ private struct ReorderTrackRow: View {
 
             Spacer()
 
-            Text(formatDuration(track.duration))
+            Text(HelperUtils.formattedShortDuration(track.duration))
                 .font(.system(size: 11))
                 .foregroundColor(.secondary)
                 .monospacedDigit()
         }
         .padding(.vertical, 4)
-    }
-
-    private func formatDuration(_ seconds: Double) -> String {
-        let minutes = Int(seconds) / 60
-        let seconds = Int(seconds) % 60
-        return String(format: StringFormat.mmss, minutes, seconds)
     }
 }
 

--- a/Views/Settings/AboutTabView.swift
+++ b/Views/Settings/AboutTabView.swift
@@ -263,8 +263,9 @@ struct AboutTabView: View {
     }
 
     private func formatTotalDuration() -> String {
-        let totalSeconds = libraryManager.databaseManager.getTotalDuration()
-        let totalHours = Int(totalSeconds) / 3600
+        let duration = libraryManager.databaseManager.getTotalDuration()
+        let totalSeconds = HelperUtils.sanitizedWholeDuration(duration)
+        let totalHours = totalSeconds / 3600
         let days = totalHours / 24
         let remainingHours = totalHours % 24
 
@@ -273,7 +274,7 @@ struct AboutTabView: View {
         } else if totalHours > 0 {
             return "\(totalHours)h"
         } else {
-            let minutes = Int(totalSeconds) / 60
+            let minutes = totalSeconds / 60
             return "\(minutes)m"
         }
     }


### PR DESCRIPTION
Harden library refresh against malformed metadata by sanitizing invalid durations before storage, display, duplicate detection, and seek calculations. Also make artist parsing’s known-artist cache thread-safe so concurrent hard refreshes can’t mutate it while scan tasks are reading it.

Fixes #286, Fixes #289