### PR TITLE
Update Player bar to show track format, refine playback controls

### DIFF
--- a/Models/Core/AudioFormatDescribing.swift
+++ b/Models/Core/AudioFormatDescribing.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Audio-format metadata shared by the lightweight `Track` and the full
+/// `FullTrack` records. The display helpers below are the single source of
+/// truth for how codec / bitrate / sample-rate / channels / lossless are
+/// rendered, used by both the player badges and the track-detail view.
+protocol AudioFormatDescribing {
+    var format: String { get }
+    var codec: String? { get }
+    var bitrate: Int? { get }
+    var sampleRate: Int? { get }
+    var channels: Int? { get }
+    var lossless: Bool? { get }
+}
+
+private enum AudioFormatTables {
+    // Canonical, properly-cased codec display names. Engines report codec casing
+    // differently (SFB upper-cases, Crescendo uses TagLib's lowercase short name),
+    // so we normalize for display. A blanket uppercase won't do - Opus/Vorbis/
+    // WavPack/Musepack aren't acronyms; unknown codecs fall back to uppercase
+    // since they're almost always acronyms.
+    static let codecDisplayNames: [String: String] = [
+        "flac": "FLAC",
+        "alac": "ALAC",
+        "aac": "AAC",
+        "mp3": "MP3",
+        "opus": "Opus",
+        "vorbis": "Vorbis",
+        "ogg": "Ogg",
+        "wav": "WAV",
+        "aiff": "AIFF",
+        "aifc": "AIFF",
+        "wavpack": "WavPack",
+        "ape": "APE",
+        "musepack": "Musepack",
+        "tta": "TTA",
+        "dsd": "DSD",
+        "speex": "Speex",
+        "pcm": "PCM"
+    ]
+}
+
+// MARK: - Display Formatting
+
+extension AudioFormatDescribing {
+    /// The codec name normalized for display, or nil when no codec is recorded.
+    var codecDisplay: String? {
+        guard let codec = codec, !codec.isEmpty else { return nil }
+        return AudioFormatTables.codecDisplayNames[codec.lowercased()] ?? codec.uppercased()
+    }
+
+    /// The bitrate formatted for display (e.g. "320 kbps"), or nil when absent.
+    /// Assumes the stored value is kbps - the metadata readers normalize to kbps
+    /// at scan time (SFB/TagLib already reports kbps; Crescendo reports bps).
+    var bitrateDisplay: String? {
+        guard let bitrate = bitrate, bitrate > 0 else { return nil }
+        return "\(bitrate) kbps"
+    }
+
+    /// The sample rate formatted for display (e.g. "44.1 kHz"), or nil when absent.
+    var sampleRateDisplay: String? {
+        guard let sampleRate = sampleRate, sampleRate > 0 else { return nil }
+        if sampleRate >= 1000 {
+            let khz = Double(sampleRate) / 1000.0
+            return String(format: "%.1f kHz", khz)
+        }
+        return "\(sampleRate) Hz"
+    }
+
+    /// The channel layout formatted for display (e.g. "Stereo"), or nil when absent.
+    var channelsDisplay: String? {
+        guard let channels = channels, channels > 0 else { return nil }
+        switch channels {
+        case 1: return String(localized: "Mono")
+        case 2: return String(localized: "Stereo")
+        case 4: return String(localized: "Quadraphonic")
+        case 6: return String(localized: "5.1 Surround")
+        case 8: return String(localized: "7.1 Surround")
+        default: return String(localized: "\(channels) channels")
+        }
+    }
+}
+
+// MARK: - Quality
+
+extension AudioFormatDescribing {
+    /// Determines if the track is in a lossless format.
+    var isLossless: Bool {
+        // Check if we already have flag set in db during metadata extraction
+        if let lossless = lossless {
+            return lossless
+        }
+
+        // Fallback to manual computation
+        let formatLower = format.lowercased()
+        let codecLower = codec?.lowercased() ?? ""
+
+        let losslessCodecs: Set<String> = [
+            "flac", "apple lossless", "alac", "wavpack", "ape", "tta",
+            "dsd", "dsf", "dff"
+        ]
+
+        for losslessCodec in losslessCodecs where codecLower.contains(losslessCodec) {
+            return true
+        }
+
+        let losslessFormats: Set<String> = [
+            // Lossless PCM
+            "flac", "alac", "wav", "wave", "aiff", "aif", "aifc",
+            // Lossless compressed
+            "ape", "wv", "tta",
+            // DSD formats
+            "dsf", "dff",
+            // Legacy lossless
+            "au",
+            // Module/tracker formats
+            "mod", "it", "s3m", "xm"
+        ]
+
+        return losslessFormats.contains(formatLower)
+    }
+}

--- a/Models/Core/FullTrack.swift
+++ b/Models/Core/FullTrack.swift
@@ -301,88 +301,13 @@ struct FullTrack: Identifiable, Equatable, Hashable, FetchableRecord, Persistabl
     }
 }
 
-// MARK: - Display Formatting
+// MARK: - Audio Format
 
-extension FullTrack {
-    // Canonical, properly-cased codec display names. Engines report codec casing
-    // differently (SFB upper-cases, Crescendo uses TagLib's lowercase short name),
-    // so we normalize for display. A blanket uppercase won't do - Opus/Vorbis/
-    // WavPack/Musepack aren't acronyms; unknown codecs fall back to uppercase
-    // since they're almost always acronyms.
-    private static let codecDisplayNames: [String: String] = [
-        "flac": "FLAC",
-        "alac": "ALAC",
-        "aac": "AAC",
-        "mp3": "MP3",
-        "opus": "Opus",
-        "vorbis": "Vorbis",
-        "ogg": "Ogg",
-        "wav": "WAV",
-        "aiff": "AIFF",
-        "aifc": "AIFF",
-        "wavpack": "WavPack",
-        "ape": "APE",
-        "musepack": "Musepack",
-        "tta": "TTA",
-        "dsd": "DSD",
-        "speex": "Speex",
-        "pcm": "PCM"
-    ]
-
-    /// The codec name normalized for display, or nil when no codec is recorded.
-    var codecDisplay: String? {
-        guard let codec = codec, !codec.isEmpty else { return nil }
-        return Self.codecDisplayNames[codec.lowercased()] ?? codec.uppercased()
-    }
-
-    /// The bitrate formatted for display (e.g. "320 kbps"), or nil when absent.
-    /// Assumes the stored value is kbps - the metadata readers normalize to kbps
-    /// at scan time (SFB/TagLib already reports kbps; Crescendo reports bps).
-    var bitrateDisplay: String? {
-        guard let bitrate = bitrate, bitrate > 0 else { return nil }
-        return "\(bitrate) kbps"
-    }
-}
+extension FullTrack: AudioFormatDescribing {}
 
 // MARK: - Quality Scoring
 
 extension FullTrack {
-    /// Determines if the track is in a lossless format
-    var isLossless: Bool {
-        // Check if we already have flag set in db during metadata extraction
-        if let lossless = lossless {
-            return lossless
-        }
-        
-        // Fallback to manual computation
-        let formatLower = format.lowercased()
-        let codecLower = codec?.lowercased() ?? ""
-        
-        let losslessCodecs: Set<String> = [
-            "flac", "apple lossless", "alac", "wavpack", "ape", "tta",
-            "dsd", "dsf", "dff"
-        ]
-        
-        for losslessCodec in losslessCodecs where codecLower.contains(losslessCodec) {
-            return true
-        }
-        
-        let losslessFormats: Set<String> = [
-            // Lossless PCM
-            "flac", "alac", "wav", "wave", "aiff", "aif", "aifc",
-            // Lossless compressed
-            "ape", "wv", "tta",
-            // DSD formats
-            "dsf", "dff",
-            // Legacy lossless
-            "au",
-            // Module/tracker formats
-            "mod", "it", "s3m", "xm"
-        ]
-        
-        return losslessFormats.contains(formatLower)
-    }
-
     /// Calculate a quality score for duplicate detection
     /// Higher score = better quality
     var qualityScore: Int {

--- a/Models/Core/Track.swift
+++ b/Models/Core/Track.swift
@@ -18,6 +18,13 @@ struct Track: Identifiable, Equatable, Hashable, FetchableRecord, PersistableRec
     let format: String
     var folderId: Int64?
     var lossless: Bool?
+
+    // Audio format details (read-only projection, populated from the tracks table).
+    // Used for the format badges in the player; not written back via `encode`.
+    var codec: String?
+    var bitrate: Int?
+    var sampleRate: Int?
+    var channels: Int?
     
     // Navigation fields (for "Go to" functionality)
     var albumArtist: String?
@@ -101,6 +108,10 @@ struct Track: Identifiable, Equatable, Hashable, FetchableRecord, PersistableRec
         static let duration = Column("duration")
         static let format = Column("format")
         static let lossless = Column("lossless")
+        static let codec = Column("codec")
+        static let bitrate = Column("bitrate")
+        static let sampleRate = Column("sample_rate")
+        static let channels = Column("channels")
         static let dateAdded = Column("date_added")
         static let isFavorite = Column("is_favorite")
         static let playCount = Column("play_count")
@@ -132,6 +143,10 @@ struct Track: Identifiable, Equatable, Hashable, FetchableRecord, PersistableRec
         let storedDuration: Double = row[Columns.duration]
         duration = HelperUtils.sanitizedDuration(storedDuration)
         lossless = row[Columns.lossless]
+        codec = row[Columns.codec]
+        bitrate = row[Columns.bitrate]
+        sampleRate = row[Columns.sampleRate]
+        channels = row[Columns.channels]
         dateAdded = row[Columns.dateAdded]
         isFavorite = row[Columns.isFavorite]
         playCount = row[Columns.playCount]
@@ -194,6 +209,10 @@ struct Track: Identifiable, Equatable, Hashable, FetchableRecord, PersistableRec
     }
 }
 
+// MARK: - Audio Format
+
+extension Track: AudioFormatDescribing {}
+
 // MARK: - Helper Methods
 
 extension Track {
@@ -231,6 +250,11 @@ extension Track {
             Columns.year,
             Columns.duration,
             Columns.format,
+            Columns.lossless,
+            Columns.codec,
+            Columns.bitrate,
+            Columns.sampleRate,
+            Columns.channels,
             Columns.dateAdded,
             Columns.isFavorite,
             Columns.playCount,

--- a/Views/Components/TrackViews/TrackTableView.swift
+++ b/Views/Components/TrackViews/TrackTableView.swift
@@ -291,7 +291,7 @@ struct TrackTableView: View {
                 
                 // Duration
                 TableColumn("Duration", value: \.duration) { track in
-                    Text(HelperUtils.formattedShortDuration(track.duration))
+                    Text(HelperUtils.formattedDuration(track.duration))
                         .font(isCurrentTrack(track) ? Self.currentTrackFont : Self.trackFont)
                         .foregroundColor(.secondary)
                         .monospacedDigit()

--- a/Views/Components/ViewExtensions.swift
+++ b/Views/Components/ViewExtensions.swift
@@ -54,6 +54,34 @@ extension View {
     }
 }
 
+// MARK: - Lossless Label
+
+/// A glyph + "Lossless" label, shared between the track-detail view and the
+/// player's format badges. Defaults match the track-detail sizing; the player
+/// passes a more compact configuration.
+struct LosslessLabel: View {
+    var iconSize: CGFloat = 14
+    var font: Font = .subheadline
+    var spacing: CGFloat = 5
+
+    var body: some View {
+        HStack(spacing: spacing) {
+            Image(Icons.customLossless)
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: iconSize, height: iconSize)
+                .foregroundColor(.secondary)
+
+            Text("Lossless")
+                .font(font)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .fixedSize()
+        }
+    }
+}
+
 // MARK: - Gradient Background
 
 struct GradientBackground: View {

--- a/Views/Main/ContentView.swift
+++ b/Views/Main/ContentView.swift
@@ -233,7 +233,7 @@ struct ContentView: View {
             Divider()
 
             PlayerView(rightSidebarContent: $rightSidebarContent)
-                .frame(height: 90)
+                .frame(height: 110)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
         }
     }

--- a/Views/Main/PlayerView.swift
+++ b/Views/Main/PlayerView.swift
@@ -87,7 +87,7 @@ struct PlayerView: View {
             albumArtwork
             trackDetails
         }
-        .frame(width: 250, alignment: .leading)
+        .frame(width: 320, alignment: .leading)
     }
 
     private var centerSection: some View {
@@ -104,7 +104,7 @@ struct PlayerView: View {
             queueButton
             lyricsButton
         }
-        .frame(width: 250, alignment: .trailing)
+        .frame(width: 320, alignment: .trailing)
     }
 
     // MARK: - Left Section Components
@@ -155,9 +155,9 @@ struct PlayerView: View {
             playlistManager.toggleShuffle()
         }, label: {
             Image(systemName: Icons.shuffleFill)
-                .font(.system(size: 14, weight: .medium))
+                .font(.system(size: 16, weight: .medium))
                 .foregroundColor(playlistManager.isShuffleEnabled ? Color.accentColor : Color.secondary)
-                .frame(width: 28, height: 28)
+                .frame(width: 32, height: 32)
         })
         .buttonStyle(ControlButtonStyle())
         .hoverEffect(scale: 1.1)
@@ -170,9 +170,9 @@ struct PlayerView: View {
             playlistManager.playPreviousTrack()
         }, label: {
             Image(systemName: Icons.backwardFill)
-                .font(.system(size: 16, weight: .medium))
+                .font(.system(size: 18, weight: .medium))
                 .foregroundColor(.primary)
-                .frame(width: 28, height: 28)
+                .frame(width: 32, height: 32)
         })
         .buttonStyle(ControlButtonStyle())
         .hoverEffect(scale: 1.1)
@@ -185,10 +185,11 @@ struct PlayerView: View {
             playbackManager.togglePlayPause()
         }, label: {
             PlayPauseIcon(isPlaying: playbackManager.isPlaying)
-                .frame(width: 36, height: 36)
+                .frame(width: 42, height: 42)
                 .background(
                     Circle()
                         .fill(Color.accentColor)
+                        .shadow(color: Color.accentColor.opacity(0.3), radius: 6, x: 0, y: 3)
                 )
         })
         .buttonStyle(PlainButtonStyle())
@@ -213,9 +214,9 @@ struct PlayerView: View {
             playlistManager.playNextTrack()
         }, label: {
             Image(systemName: Icons.forwardFill)
-                .font(.system(size: 16, weight: .medium))
+                .font(.system(size: 18, weight: .medium))
                 .foregroundColor(.primary)
-                .frame(width: 28, height: 28)
+                .frame(width: 32, height: 32)
         })
         .buttonStyle(ControlButtonStyle())
         .hoverEffect(scale: 1.1)
@@ -228,9 +229,9 @@ struct PlayerView: View {
             playlistManager.toggleRepeatMode()
         }, label: {
             Image(systemName: Icons.repeatIcon(for: playlistManager.repeatMode))
-                .font(.system(size: 14, weight: .medium))
+                .font(.system(size: 16, weight: .medium))
                 .foregroundColor(playlistManager.repeatMode != .off ? Color.accentColor : Color.secondary)
-                .frame(width: 28, height: 28)
+                .frame(width: 32, height: 32)
         })
         .buttonStyle(ControlButtonStyle())
         .hoverEffect(scale: 1.1)
@@ -248,23 +249,29 @@ struct PlayerView: View {
 
     private var progressBar: some View {
         HStack(spacing: 8) {
-            // Current time - updated to use displayTime
-            Text(HelperUtils.formattedShortDuration(isDraggingProgress ? tempProgressValue : playbackManager.currentTime))
+            // Current time
+            Text(HelperUtils.formattedDuration(isDraggingProgress ? tempProgressValue : playbackManager.currentTime))
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(.secondary)
                 .monospacedDigit()
-                .frame(width: 40, alignment: .trailing)
+                .frame(width: timeLabelWidth, alignment: .trailing)
 
             // Progress slider
             progressSlider
 
             // Total duration
-            Text(HelperUtils.formattedShortDuration(playbackManager.currentTrack?.duration ?? 0))
+            Text(HelperUtils.formattedDuration(playbackManager.currentTrack?.duration ?? 0))
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(.secondary)
                 .monospacedDigit()
-                .frame(width: 40, alignment: .leading)
+                .frame(width: timeLabelWidth, alignment: .leading)
         }
+    }
+
+    /// Widens the time labels when the current track is an hour or longer so the
+    /// `H:MM:SS` form isn't clipped; otherwise keeps the compact `M:SS` width.
+    private var timeLabelWidth: CGFloat {
+        (playbackManager.currentTrack?.duration ?? 0) >= 3600 ? 56 : 40
     }
 
     private var progressSlider: some View {
@@ -283,6 +290,7 @@ struct PlayerView: View {
                             width: geometry.size.width * progressPercentage,
                             height: 4
                         )
+                        .animation(isDraggingProgress ? .none : .easeInOut(duration: 0.2), value: progressPercentage)
 
                     // Drag handle
                     Circle()
@@ -290,7 +298,7 @@ struct PlayerView: View {
                         .frame(width: 12, height: 12)
                         .opacity(isDraggingProgress || hoveredOverProgress ? 1.0 : 0.0)
                         .offset(x: (geometry.size.width * progressPercentage) - 6)
-                        .animation(isDraggingProgress ? .none : .easeInOut(duration: 0.15), value: progressPercentage)
+                        .animation(isDraggingProgress ? .none : .easeInOut(duration: 0.2), value: progressPercentage)
                         .animation(.easeInOut(duration: 0.15), value: hoveredOverProgress)
                 }
                 .contentShape(Rectangle())
@@ -479,7 +487,7 @@ struct PlayerView: View {
     }
 
     private func progressDragGesture(in geometry: GeometryProxy) -> some Gesture {
-        DragGesture(minimumDistance: 0)
+        DragGesture(minimumDistance: 4)
             .onChanged { value in
                 if !isDraggingProgress {
                     isDraggingProgress = true
@@ -521,8 +529,6 @@ struct PlayerView: View {
     }
 }
 
-// Keep the existing supporting views and structs below...
-
 // MARK: - Album Art
 
 struct PlayerTrackDetailsView: View, Equatable {
@@ -556,6 +562,7 @@ struct PlayerTrackDetailsView: View, Equatable {
                     ) { playlistManager.toggleFavorite(for: track) }
                 }
             }
+            .frame(height: 16)
             .frame(maxWidth: .infinity, alignment: .leading)
 
             // Artist with marquee
@@ -564,7 +571,7 @@ struct PlayerTrackDetailsView: View, Equatable {
                 font: .system(size: 12),
                 color: .secondary
             )
-            .frame(height: 16)
+            .frame(height: 15)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contextMenu {
                 TrackContextMenuContent(items: contextMenuItems)
@@ -576,13 +583,60 @@ struct PlayerTrackDetailsView: View, Equatable {
                 font: .system(size: 11),
                 color: .secondary
             )
-            .frame(height: 14)
+            .frame(height: 15)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contextMenu {
                 TrackContextMenuContent(items: contextMenuItems)
             }
+            
+            formatBadgeRow
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var formatBadgeRow: some View {
+        HStack(spacing: 4) {
+            if let track = track {
+                if track.isLossless {
+                    LosslessLabel(iconSize: 12, font: .system(size: 10), spacing: 3)
+                }
+                if let codec = track.codecDisplay {
+                    FormatBadge(text: codec)
+                }
+                // No need to show Bitrate for Lossless tracks, as it is pointless
+                if !track.isLossless, let bitrate = track.bitrateDisplay {
+                    FormatBadge(text: bitrate)
+                }
+                if let sampleRate = track.sampleRateDisplay {
+                    FormatBadge(text: sampleRate)
+                }
+                if let channels = track.channelsDisplay {
+                    FormatBadge(text: channels)
+                }
+            }
+        }
+        .frame(height: 15)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Format Badge
+
+private struct FormatBadge: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 9, weight: .medium))
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+            .fixedSize()
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.secondary.opacity(0.2))
+            )
     }
 }
 
@@ -648,7 +702,7 @@ private struct AlbumArtworkImage: View {
             // Static image content
             AlbumArtworkContent(trackInfo: trackInfo)
         }
-        .frame(width: 56, height: 56)
+        .frame(width: 76, height: 76)
         .shadow(
             color: .black.opacity(isHovered ? 0.4 : 0.2),
             radius: isHovered ? 6 : 2,
@@ -673,14 +727,14 @@ private struct AlbumArtworkContent: View {
             Image(nsImage: nsImage)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
-                .frame(width: 56, height: 56)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .frame(width: 76, height: 76)
+                .clipShape(RoundedRectangle(cornerRadius: 5))
         } else {
-            RoundedRectangle(cornerRadius: 4)
+            RoundedRectangle(cornerRadius: 5)
                 .fill(Color.secondary.opacity(0.15))
                 .overlay(
                     Image(systemName: Icons.musicNote)
-                        .font(.system(size: 16, weight: .light))
+                        .font(.system(size: 22, weight: .light))
                         .foregroundColor(.secondary)
                 )
         }
@@ -704,14 +758,14 @@ private struct PlayPauseIcon: View {
     var body: some View {
         ZStack {
             Image(systemName: Icons.playFill)
-                .font(.system(size: 18, weight: .medium))
+                .font(.system(size: 20, weight: .medium))
                 .foregroundColor(.white)
                 .opacity(isPlaying ? 0 : 1)
                 .scaleEffect(isPlaying ? 0.8 : 1)
                 .rotationEffect(.degrees(isPlaying ? -90 : 0))
 
             Image(systemName: Icons.pauseFill)
-                .font(.system(size: 18, weight: .medium))
+                .font(.system(size: 20, weight: .medium))
                 .foregroundColor(.white)
                 .opacity(isPlaying ? 1 : 0)
                 .scaleEffect(isPlaying ? 1 : 0.8)

--- a/Views/Main/TrackDetailView.swift
+++ b/Views/Main/TrackDetailView.swift
@@ -217,18 +217,7 @@ struct TrackDetailView: View {
             }
             
             if fullTrack.isLossless {
-                HStack(spacing: 5) {
-                    Image(Icons.customLossless)
-                        .renderingMode(.template)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 14, height: 14)
-                        .foregroundColor(.secondary)
-
-                    Text("Lossless")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                }
+                LosslessLabel()
             }
         }
     }
@@ -486,17 +475,16 @@ private struct FileDetailsSection: View {
             items.append((String(localized: "Bitrate"), bitrate))
         }
 
-        if let sampleRate = fullTrack.sampleRate, sampleRate > 0 {
-            let formatted = formatSampleRate(sampleRate)
-            items.append((String(localized: "Sample Rate"), formatted))
+        if let sampleRate = fullTrack.sampleRateDisplay {
+            items.append((String(localized: "Sample Rate"), sampleRate))
         }
 
         if let bitDepth = fullTrack.bitDepth, bitDepth > 0 {
             items.append((String(localized: "Bit Depth"), String(localized: "\(bitDepth)-bit")))
         }
 
-        if let channels = fullTrack.channels, channels > 0 {
-            items.append((String(localized: "Channels"), formatChannels(channels)))
+        if let channels = fullTrack.channelsDisplay {
+            items.append((String(localized: "Channels"), channels))
         }
 
         // File info
@@ -522,25 +510,6 @@ private struct FileDetailsSection: View {
         }
 
         return items
-    }
-
-    private func formatSampleRate(_ sampleRate: Int) -> String {
-        if sampleRate >= 1000 {
-            let khz = Double(sampleRate) / 1000.0
-            return String(format: "%.1f kHz", khz)
-        }
-        return "\(sampleRate) Hz"
-    }
-
-    private func formatChannels(_ channels: Int) -> String {
-        switch channels {
-        case 1: return String(localized: "Mono")
-        case 2: return String(localized: "Stereo")
-        case 4: return String(localized: "Quadraphonic")
-        case 6: return String(localized: "5.1 Surround")
-        case 8: return String(localized: "7.1 Surround")
-        default: return String(localized: "\(channels) channels")
-        }
     }
 
     private func formatFileSize(_ bytes: Int64) -> String {


### PR DESCRIPTION
Updates Player bar with following changes;

- Showing technical track info like, lossless, codec, bitrate, sample rate, & channels.
- Update play/pause button style, animating progress bar seek
- Format track duration to use H:MM:SS (Fixes #302)

<img width="1377" height="136" alt="image" src="https://github.com/user-attachments/assets/838e6b68-1e4f-468a-8882-3eecb5d9f5b1" />
