### PR TITLE
Fix app crash on macOS 14, other UI updates

### DIFF
--- a/Managers/MenuBarManager.swift
+++ b/Managers/MenuBarManager.swift
@@ -48,10 +48,13 @@ class MenuBarManager: NSObject {
 
     @objc
     private func handleCloseToMenubarChange() {
-        if UserDefaults.standard.bool(forKey: "closeToMenubar") {
-            setupMenuBar()
-        } else {
-            removeMenuBar()
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if UserDefaults.standard.bool(forKey: "closeToMenubar") {
+                self.setupMenuBar()
+            } else {
+                self.removeMenuBar()
+            }
         }
     }
 

--- a/Utilities/Constants.swift
+++ b/Utilities/Constants.swift
@@ -57,8 +57,7 @@ enum Icons {
     static let arrowClockwise = "arrow.clockwise"
     static let arrowClockwiseCircle = "arrow.clockwise.circle"
     static let globe = "globe"
-    static let globeFill = "globe.fill"
-    
+
     // Entity Icons
     static let personFill = "person.fill"
     static let person2Fill = "person.2.fill"

--- a/Views/Main/ContentView.swift
+++ b/Views/Main/ContentView.swift
@@ -21,7 +21,6 @@ struct ContentView: View {
     @State private var rightSidebarContent: RightSidebarContent = .none
     @State private var pendingLibraryFilter: LibraryFilterRequest?
     @State private var windowDelegate = WindowDelegate()
-    @State private var isSettingsHovered = false
     @State private var shouldFocusSearch = false
     @State private var showingExportPlaylistSheet = false
 
@@ -268,9 +267,6 @@ struct ContentView: View {
                 )
                 .frame(width: 280)
                 .disabled(!libraryManager.shouldShowMainUI)
-                
-                settingsButton
-                    .disabled(!libraryManager.shouldShowMainUI)
             }
         }
     }
@@ -305,27 +301,6 @@ struct ContentView: View {
         }
     }
     
-    private var settingsButton: some View {
-        Button(action: {
-            showingSettings = true
-        }, label: {
-            Image(systemName: "gear")
-                .font(.system(size: 16))
-                .frame(width: 24, height: 24)
-                .foregroundColor(isSettingsHovered ? .primary : .secondary)
-        })
-        .buttonStyle(.borderless)
-        .background(
-            Circle()
-                .fill(Color.gray.opacity(isSettingsHovered ? 0.1 : 0))
-                .animation(.easeInOut(duration: AnimationDuration.standardDuration), value: isSettingsHovered)
-        )
-        .onHover { hovering in
-            isSettingsHovered = hovering
-        }
-        .help("Settings")
-    }
-
     // MARK: - Event Handlers
 
     private func handleOnAppear() {

--- a/Views/Settings/SettingsView.swift
+++ b/Views/Settings/SettingsView.swift
@@ -26,7 +26,7 @@ struct SettingsView: View {
             switch self {
             case .general: return Icons.settings
             case .library: return Icons.customMusicNoteRectangleStack
-            case .online: return Icons.globeFill
+            case .online: return Icons.globe
             case .about: return Icons.infoCircleFill
             }
         }


### PR DESCRIPTION
Makes following fixes/changes for macOS 14 & 15

- Crash on launch in macOS 15 when close to menubar is enabled
- Missing tab icon for Online tab in Settings sheet when tab is selected
- Remove Settings button from Window frame to make it consistent with newer macOS versions