### PR TITLE
Fix various issues across the app following the feature changes

### DIFF
--- a/Managers/ArtistBioManager.swift
+++ b/Managers/ArtistBioManager.swift
@@ -102,9 +102,29 @@ class ArtistBioManager {
             var lastUIUpdate = Date.distantPast
             let uiUpdateInterval: TimeInterval = 2
 
+            // Stop a doomed run (offline / APIs down) instead of timing out on every
+            // artist. The list is popular-first, so a long run yielding neither image
+            // nor bio means "offline", not "no data exists".
+            let maxConsecutiveFailures = 10
+            var consecutiveFailures = 0
+            var stoppedEarly = false
+
+            // Full (image+bio) misses deferred until we can tell "offline" from "no
+            // data": a success or finishing the whole list stamps them; any early exit
+            // (offline breaker or cancel) drops them so a later refresh retries them.
+            var deferredFullMisses: [Int64] = []
+            func flushDeferredFailures() {
+                for artistId in deferredFullMisses {
+                    databaseManager.markArtistImageFetchFailed(artistId: artistId)
+                    databaseManager.markArtistBioFetchFailed(artistId: artistId)
+                }
+                deferredFullMisses.removeAll()
+            }
+
             for artist in artists {
                 guard !Task.isCancelled, self.isArtistInfoFetchEnabled else {
                     Logger.info("Fetch stopped")
+                    stoppedEarly = true
                     break
                 }
 
@@ -112,6 +132,13 @@ class ArtistBioManager {
                 Logger.info("Fetching info for '\(artist.name)' (image: \(!artist.hasImage), bio: \(!artist.hasBio))")
                 let imageResult = artist.hasImage ? nil : await self.fetchArtistImage(name: artist.name)
                 let bio = artist.hasBio ? nil : await self.fetchArtistBio(name: artist.name)
+
+                // A cancel mid-fetch surfaces as nil results; bail before treating them
+                // as misses so we don't stamp an interrupted artist as failed.
+                if Task.isCancelled {
+                    stoppedEarly = true
+                    break
+                }
 
                 if let imageResult,
                    let compressed = ImageUtils.compressImage(from: imageResult.imageData, source: "ArtistBioManager/\(imageResult.source)") {
@@ -127,17 +154,37 @@ class ArtistBioManager {
                     pendingUpdates.append((name: artist.name, artworkData: compressed))
                 } else if let bio {
                     databaseManager.updateArtistInfo(artistId: artist.id, bio: bio, bioSource: "last.fm")
-                    if !artist.hasImage {
-                        databaseManager.markArtistImageFetchFailed(artistId: artist.id)
-                    }
-                } else if !artist.hasImage {
-                    databaseManager.markArtistImageFetchFailed(artistId: artist.id)
                 }
 
-                // Stamp bioUpdatedAt when a bio fetch was attempted but returned nil,
-                // so we don't re-query the same artist on every run.
-                if !artist.hasBio && bio == nil {
-                    databaseManager.markArtistBioFetchFailed(artistId: artist.id)
+                // A miss = an attempted fetch that got an empty remote response.
+                // (A downloaded image that fails local compression is not a miss; it
+                // stays unstamped so it retries rather than being skipped for 7 days.)
+                let imageMiss = !artist.hasImage && imageResult == nil
+                let bioMiss = !artist.hasBio && bio == nil
+
+                if imageResult != nil || bio != nil {
+                    // Got data, so we're online: flush deferred full misses (genuine),
+                    // stamp this artist's own miss, reset the breaker.
+                    flushDeferredFailures()
+                    if imageMiss { databaseManager.markArtistImageFetchFailed(artistId: artist.id) }
+                    if bioMiss { databaseManager.markArtistBioFetchFailed(artistId: artist.id) }
+                    consecutiveFailures = 0
+                } else if imageMiss && bioMiss {
+                    // Both attempted fields came back empty: an offline candidate.
+                    // Defer the stamps and count toward the breaker.
+                    deferredFullMisses.append(artist.id)
+                    consecutiveFailures += 1
+                    if consecutiveFailures >= maxConsecutiveFailures {
+                        Logger.warning("Stopping artist fetch after \(maxConsecutiveFailures) consecutive failures (likely offline)")
+                        stoppedEarly = true
+                        break
+                    }
+                } else {
+                    // Only one field was attempted and authoritatively returned nothing
+                    // (e.g. no Last.fm bio exists, or no Last.fm key): a genuine miss,
+                    // not evidence of offline. Stamp it; leave the breaker untouched.
+                    if imageMiss { databaseManager.markArtistImageFetchFailed(artistId: artist.id) }
+                    if bioMiss { databaseManager.markArtistBioFetchFailed(artistId: artist.id) }
                 }
 
                 // Flush pending UI updates every 2 seconds
@@ -147,6 +194,10 @@ class ArtistBioManager {
                     lastUIUpdate = Date()
                 }
             }
+
+            // Stamp trailing full misses only if we finished the whole list; any early
+            // exit (offline or cancel) leaves them for a later retry.
+            if !stoppedEarly { flushDeferredFailures() }
 
             // Flush remaining updates
             if !pendingUpdates.isEmpty {
@@ -214,9 +265,8 @@ class ArtistBioManager {
                 }
             }
             return images
-        } catch is CancellationError {
-            return []
         } catch {
+            if isCancellation(error) { return [] }
             Logger.error("MusicBrainz error for '\(name)': \(error.localizedDescription)")
             return []
         }
@@ -252,9 +302,8 @@ class ArtistBioManager {
                 }
             }
             return nil
-        } catch is CancellationError {
-            return nil
         } catch {
+            if isCancellation(error) { return nil }
             Logger.error("MusicBrainz lookup error for MBID '\(mbid)': \(error.localizedDescription)")
             return nil
         }
@@ -301,9 +350,8 @@ class ArtistBioManager {
                 return ImageResult(imageData: imageData, imageUrl: imageUrl, source: label)
             }
             return nil
-        } catch is CancellationError {
-            return nil
         } catch {
+            if isCancellation(error) { return nil }
             Logger.error("Wikidata error for '\(qid)': \(error.localizedDescription)")
             return nil
         }
@@ -367,9 +415,8 @@ class ArtistBioManager {
                 }
             }
             return images
-        } catch is CancellationError {
-            return []
         } catch {
+            if isCancellation(error) { return [] }
             Logger.error("TMDB error for '\(name)': \(error.localizedDescription)")
             return []
         }
@@ -409,15 +456,14 @@ class ArtistBioManager {
                 return nil
             }
 
-            // Last.fm appends a "Read more" link in HTML — strip it
+            // Last.fm appends a "Read more" link in HTML
             let cleaned = content
                 .replacingOccurrences(of: "<a href=\".*?\">.*?</a>", with: "", options: .regularExpression)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
 
             return cleaned.isEmpty ? nil : cleaned
-        } catch is CancellationError {
-            return nil
         } catch {
+            if isCancellation(error) { return nil }
             Logger.error("Last.fm bio error for '\(name)': \(error.localizedDescription)")
             return nil
         }
@@ -437,6 +483,14 @@ class ArtistBioManager {
     }
 
     // MARK: - Helpers
+
+    /// A cancelled URLSession request throws `URLError.cancelled`, not `CancellationError`,
+    /// so the fetch task being restarted/cancelled would otherwise log as an error.
+    private func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        if let urlError = error as? URLError, urlError.code == .cancelled { return true }
+        return false
+    }
 
     private func downloadImageData(from urlString: String) async -> Data? {
         guard let url = URL(string: urlString) else { return nil }

--- a/Managers/Database/DMMetadata.swift
+++ b/Managers/Database/DMMetadata.swift
@@ -388,7 +388,10 @@ extension DatabaseManager {
                         Artist.Columns.imageSource,
                         Artist.Columns.bio
                     )
+                    // INNER JOIN to require >=1 track; .distinct() collapses the
+                    // per-(artist, track) rows it emits (artist with N tracks -> N rows).
                     .joining(required: Artist.tracks)
+                    .distinct()
                     .filter(needsImage || needsBio)
                     .order(Artist.Columns.totalTracks.desc)
                     .asRequest(of: Row.self)

--- a/Managers/Database/DMTrackProcessing.swift
+++ b/Managers/Database/DMTrackProcessing.swift
@@ -55,18 +55,33 @@ extension DatabaseManager {
         totalFilesInFolder: Int? = nil,
         globalScanState: GlobalScanState? = nil
     ) async throws {
-        let chunkSize = max(100, ProcessInfo.processInfo.activeProcessorCount * 12)
-        
-        Logger.info("Processing batch of \(batch.count) files in chunks of \(chunkSize)")
-        
+        let chunkSize = 100  // DB-write batch + progress cadence
+        // Bound concurrent parses. Saturating every cooperative-pool thread (each
+        // briefly blocks on GRDB/artwork work) deadlocks macOS 14's runtime; 15+
+        // recovers, so only 14 needs headroom.
+        let cores = ProcessInfo.processInfo.activeProcessorCount
+        let maxConcurrent: Int
+        if #available(macOS 15, *) {
+            maxConcurrent = max(4, cores)
+        } else {
+            maxConcurrent = max(2, cores / 2)
+        }
+
+        Logger.info("Processing batch of \(batch.count) files in chunks of \(chunkSize), up to \(maxConcurrent) concurrent")
+
         let chunks = batch.chunked(into: chunkSize)
-        
+
         for chunk in chunks {
             let artworkCache = ArtworkCompressionCache()
             let lazyArtwork = artworkPaths.isEmpty ? nil : LazyArtworkLoader(artworkPaths: artworkPaths)
 
             let results = try await withThrowingTaskGroup(of: (URL, TrackProcessResult).self) { group in
-                for item in chunk {
+                var chunkResults: [(URL, TrackProcessResult)] = []
+                chunkResults.reserveCapacity(chunk.count)
+
+                var iterator = chunk.makeIterator()
+
+                func addTask(for item: (url: URL, folderId: Int64)) {
                     group.addTask { [weak self] in
                         guard let self = self else { return (item.url, .skipped) }
                         return await self.processFile(
@@ -80,10 +95,18 @@ extension DatabaseManager {
                         )
                     }
                 }
-                
-                var chunkResults: [(URL, TrackProcessResult)] = []
-                for try await result in group {
+
+                // Keep at most `maxConcurrent` parses in flight: prime, then refill
+                // on each completion.
+                for _ in 0..<maxConcurrent {
+                    guard let item = iterator.next() else { break }
+                    addTask(for: item)
+                }
+                while let result = try await group.next() {
                     chunkResults.append(result)
+                    if let item = iterator.next() {
+                        addTask(for: item)
+                    }
                 }
                 return chunkResults
             }

--- a/Managers/Library/LMFolders.swift
+++ b/Managers/Library/LMFolders.swift
@@ -88,33 +88,60 @@ extension LibraryManager {
 
     func refreshFolder(_ folder: Folder, hardRefresh: Bool = false) {
         // First, ensure we have a valid bookmark
-        Task {
+        Task { [weak self] in
+            guard let self = self else { return }
+
             // Every successful start must be paired with a stop; track whether we took a ref.
             let startedAccess = folder.bookmarkData != nil
                 && folder.url.startAccessingSecurityScopedResource()
             if !startedAccess {
-                await refreshBookmarkForFolder(folder)
+                await self.refreshBookmarkForFolder(folder)
             }
 
-            // Then proceed with scanning
-            await MainActor.run { [weak self] in
-                guard let self = self else {
-                    if startedAccess { folder.url.stopAccessingSecurityScopedResource() }
-                    return
-                }
+            // Show the indicator before counting: enumerating a large folder can take
+            // a moment, and refreshLibrary() starts activity before counting too.
+            await MainActor.run {
+                NotificationManager.shared.startActivity(String(localized: "Refreshing \(folder.name)..."))
+            }
 
-                // Delegate to database manager for refresh
-                self.databaseManager.refreshFolder(folder, hardRefresh: hardRefresh) { result in
-                    if startedAccess { folder.url.stopAccessingSecurityScopedResource() }
-                    switch result {
-                    case .success:
-                        Logger.info("Successfully refreshed folder \(folder.name)")
-                        // Reload the library to reflect changes
-                        self.refreshLibraryCategories()
-                        self.loadMusicLibrary()
-                    case .failure(let error):
-                        Logger.error("Failed to refresh folder \(folder.name): \(error)")
-                    }
+            // Pre-count files so the progress bar can advance (needs a
+            // GlobalScanState); skip on slow filesystems, like refreshLibrary().
+            let isSlowFS = FilesystemUtils.isSlowFilesystem(url: folder.url)
+            let totalFiles = isSlowFS
+                ? 0
+                : await self.databaseManager.countFilesInFolder(
+                    folder,
+                    supportedExtensions: AudioFormat.supportedExtensions
+                )
+            let globalScanState = GlobalScanState(totalFiles: totalFiles)
+
+            // startActivity() above cleared progress; set the initial total now that
+            // we know it (the first update always passes the throttle after a start).
+            await MainActor.run {
+                NotificationManager.shared.updateActivityProgress(
+                    current: 0,
+                    total: totalFiles,
+                    detail: totalFiles > 0 ? String(localized: "0 of \(totalFiles) files") : String(localized: "Preparing files...")
+                )
+            }
+
+            // completion runs on the main actor (see DMFolders.refreshFolder)
+            self.databaseManager.refreshFolder(
+                folder,
+                hardRefresh: hardRefresh,
+                manageActivityIndicator: false,
+                globalScanState: globalScanState
+            ) { result in
+                if startedAccess { folder.url.stopAccessingSecurityScopedResource() }
+                NotificationManager.shared.stopActivity()
+                switch result {
+                case .success:
+                    Logger.info("Successfully refreshed folder \(folder.name)")
+                    // Reload the library to reflect changes
+                    self.refreshLibraryCategories()
+                    self.loadMusicLibrary()
+                case .failure(let error):
+                    Logger.error("Failed to refresh folder \(folder.name): \(error)")
                 }
             }
         }

--- a/Managers/Library/LMLibrary.swift
+++ b/Managers/Library/LMLibrary.swift
@@ -218,6 +218,11 @@ extension LibraryManager {
             // Only proceed if there are folders to refresh
             if foldersToRefresh.isEmpty {
                 Logger.info("No folders need refreshing")
+                // Still retry missing artist info: it's independent of track changes,
+                // and this is the manual-refresh resume path for the offline breaker.
+                await MainActor.run { [weak self] in
+                    if let self { ArtistBioManager.shared.fetchMissingArtistImages(using: self) }
+                }
                 return
             }
 
@@ -297,9 +302,14 @@ extension LibraryManager {
                 self?.loadMusicLibrary()
                 self?.updateSearchResults()
                 self?.updateTotalCounts()
-                
+
                 // Stop activity after everything is done
                 NotificationManager.shared.stopActivity()
+
+                // Retry missing artist info now the library is current; also how the
+                // breaker resumes while the app stays open (each refresh re-attempts
+                // unstamped artists). No-op when nothing's missing or the feature's off.
+                if let self { ArtistBioManager.shared.fetchMissingArtistImages(using: self) }
             }
 
             // Add notifications based on results

--- a/Managers/PlaybackManager.swift
+++ b/Managers/PlaybackManager.swift
@@ -70,6 +70,9 @@ class PlaybackManager: NSObject, ObservableObject {
 
     /// Identity of the track currently loaded in the engine.
     private var currentEntryId: AudioEntryId?
+    /// Maps engine entry id -> the track it plays, so a finish can credit the track
+    /// that actually ended even after a gapless advance promoted the next one.
+    private var trackForEntry: [String: Track] = [:]
     /// The pre-decoded next track (the "+1") primed into a gapless engine, or nil.
     private var pendingNext: PendingNext?
     /// Set when the primed next track was rejected by the engine. On EOF, fall back
@@ -425,6 +428,8 @@ class PlaybackManager: NSObject, ObservableObject {
         // any previously primed gapless next is gone.
         let entryId = AudioEntryId(id: UUID().uuidString)
         currentEntryId = entryId
+        // Fresh play replaces the engine queue, so prior entries are gone.
+        trackForEntry = [entryId.id: lightweightTrack]
         pendingNext = nil
         pendingNextWasSkipped = false
 
@@ -525,6 +530,8 @@ class PlaybackManager: NSObject, ObservableObject {
         currentTrack = pending.track
         currentFullTrack = pending.fullTrack
         currentEntryId = pending.entryId
+        // Keep the outgoing entry so its (possibly late) finish can still credit it.
+        trackForEntry[pending.entryId.id] = pending.track
         playlistManager.advanceQueueIndex(to: pending.index)
         currentTime = 0
         isPlaying = true
@@ -561,7 +568,9 @@ class PlaybackManager: NSObject, ObservableObject {
         timer.schedule(deadline: .now(), repeating: interval, leeway: .milliseconds(50))
 
         timer.setEventHandler { [weak self] in
-            guard let self = self, self.isPlaying else { return }
+            // Gate on the engine's live state, not the cached isPlaying flag, which
+            // can be briefly stale and freeze the bar at 0.
+            guard let self = self, self.audioPlayer.state == .playing else { return }
             self.currentTime = self.audioPlayer.currentPlaybackProgress
             // Refresh the system Now Playing tile at ~1s regardless of sampling
             // rate - it extrapolates elapsed between updates from the rate anchor,
@@ -736,31 +745,36 @@ extension PlaybackManager: AudioPlayerDelegate {
         duration: Double
     ) {
         DispatchQueue.main.async {
-            guard let currentTrack = self.currentTrack else {
+            // Credit the track that actually finished, resolved by entry id: on a
+            // gapless advance currentTrack may already be the next track.
+            let finishedTrack = self.trackForEntry.removeValue(forKey: entryId.id)
+
+            guard self.currentTrack != nil else {
                 Logger.info("Ignoring finish - no current track")
                 return
             }
-            
+
             Logger.info("Track finished (reason: \(stopReason))")
-            
-            if stopReason == .eof {
-                // Fires before the next track's didStartPlaying on a gapless
-                // advance, so currentTrack is still the finished (outgoing) track.
-                self.playlistManager.incrementPlayCount(for: currentTrack)
-                self.scrobbleManager?.trackFinished(currentTrack)
+
+            if stopReason == .eof, let finishedTrack {
+                self.playlistManager.incrementPlayCount(for: finishedTrack)
+                self.scrobbleManager?.trackFinished(finishedTrack)
 
                 Logger.info("Track completed naturally, updating play count, last played date, and scrobbling it if configured")
             }
+
+            // Only tear down current playback when the finished entry is still
+            // current; a stale finish that raced ahead of a gapless advance must not
+            // flip isPlaying false under the now-playing track (which freezes its bar).
+            let finishedEntryIsCurrent = entryId == self.currentEntryId
 
             switch stopReason {
             case .eof:
                 self.restoredPosition = 0
                 if self.audioPlayer.supportsGaplessQueue {
-                    // The engine self-advances gaplessly; the primed next track's
-                    // didStartPlaying promotes it. Only handle a true end of queue
-                    // here (nothing was primed). Don't reset currentTime - the
-                    // incoming track owns it now.
-                    if self.pendingNext == nil {
+                    // True end of queue only: nothing primed and this finish is for
+                    // the current entry (not a stale one that raced the advance).
+                    if self.pendingNext == nil && finishedEntryIsCurrent {
                         self.currentTime = 0
                         if self.pendingNextWasSkipped {
                             self.pendingNextWasSkipped = false

--- a/Managers/ScrobbleManager.swift
+++ b/Managers/ScrobbleManager.swift
@@ -107,6 +107,16 @@ class ScrobbleManager: ObservableObject {
         }
     }
     
+    /// Re-sends "Now Playing" when scrobbling is enabled mid-track; otherwise it'd
+    /// only update on the next track. trackStarted() self-guards, so it's a no-op
+    /// when not applicable.
+    func scrobblingEnabledDuringPlayback() {
+        guard let playbackManager = AppCoordinator.shared?.playbackManager,
+              playbackManager.isPlaying,
+              let track = playbackManager.currentTrack else { return }
+        trackStarted(track)
+    }
+
     /// Called when user favorites/unfavorites a track - syncs love status to Last.fm
     func trackLoveStatusChanged(_ track: Track, isLoved: Bool) {
         guard isConnected, isLoveSyncEnabled else { return }

--- a/Views/MiniPlayer/MiniPlayerWindowManager.swift
+++ b/Views/MiniPlayer/MiniPlayerWindowManager.swift
@@ -20,7 +20,7 @@ import AppKit
 final class MiniPlayerWindowManager: NSObject {
     static let shared = MiniPlayerWindowManager()
 
-    private static let frameAutosaveName = "PetrichorMiniPlayerWindow"
+    private static let frameKey = "PetrichorMiniPlayerWindow"
 
     private var window: NSWindow?
 
@@ -69,21 +69,45 @@ final class MiniPlayerWindowManager: NSObject {
         window.collectionBehavior = [.fullScreenAuxiliary]
         window.delegate = self
 
-        // Persist size + position (including which display) across relaunches,
-        // like the main window. Restores the saved frame if present, else centers.
-        if !window.setFrameUsingName(Self.frameAutosaveName) {
-            window.center()
-        }
-        window.setFrameAutosaveName(Self.frameAutosaveName)
+        // We persist the frame ourselves: NSWindow's autosave remaps onto the main
+        // display in multi-monitor setups.
+        restoreFrame(into: window)
 
         self.window = window
 
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }
+
+    /// Restores the saved global frame (origin encodes the display) when it's still
+    /// on a connected screen; otherwise centers.
+    private func restoreFrame(into window: NSWindow) {
+        guard let saved = UserDefaults.standard.string(forKey: Self.frameKey) else {
+            window.center()
+            return
+        }
+        let frame = NSRectFromString(saved)
+        guard frame.width > 0, frame.height > 0,
+              NSScreen.screens.contains(where: { $0.frame.intersects(frame) }) else {
+            window.center()
+            return
+        }
+        window.setFrame(frame, display: false)
+    }
+
+    /// Persists the current global frame (origin includes the display).
+    private func saveFrame() {
+        guard let window else { return }
+        UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: Self.frameKey)
+    }
 }
 
 extension MiniPlayerWindowManager: NSWindowDelegate {
+    // MiniPlayerView's drag/resize fire these. saveFrame no-ops until self.window is
+    // set, so the initial restore doesn't overwrite the stored frame.
+    func windowDidMove(_ notification: Notification) { saveFrame() }
+    func windowDidResize(_ notification: Notification) { saveFrame() }
+
     func windowWillClose(_ notification: Notification) {
         // Intentionally does NOT save playback state here. During app
         // termination this fires after `applicationWillTerminate` has already

--- a/Views/Settings/IntegrationsTabView.swift
+++ b/Views/Settings/IntegrationsTabView.swift
@@ -113,6 +113,11 @@ struct IntegrationsTabView: View {
 
             Toggle("Enable scrobbling", isOn: $scrobblingEnabled)
                 .help("Track your listening history on Last.fm")
+                .onChange(of: scrobblingEnabled) { _, enabled in
+                    if enabled {
+                        AppCoordinator.shared?.scrobbleManager.scrobblingEnabledDuringPlayback()
+                    }
+                }
 
             Toggle(isOn: $loveSyncEnabled) {
                 HStack(spacing: 4) {


### PR DESCRIPTION
Fixes a few issues across the app;

1. Last.fm "Now Playing" not updated when scrobbling is toggled mid-playback from Settings > Integrations.
2. Folder refresh hangs on macOS 14, and no progress bar for single-folder forced refresh (follow-up of #297).
3. Artist info fetching: duplicate requests, and graceful offline stop/resume.
4. Remember Mini Player position in a multi-monitor setup
5. Fix occasional stuck playback progress while using Crescendo backend