### PR TITLE
Fix bilingual lyrics highlighting in LRC parser

### DIFF
--- a/Models/Core/Lyrics.swift
+++ b/Models/Core/Lyrics.swift
@@ -70,13 +70,28 @@ extension LyricLine {
             }
         }
         
-        var sorted = lyrics.sorted { $0.startTime < $1.startTime }
-        // Each line ends where the next begins, giving a gapless highlight window
-        if sorted.count > 1 {
-            for i in 0..<sorted.count - 1 {
-                sorted[i].endTime = sorted[i + 1].startTime
+        // 1. Stable sort: break ties using original array index so authored line order is preserved
+        var indexedLyrics = lyrics.enumerated().map { (offset: $0.offset, line: $0.element) }
+        indexedLyrics.sort { lhs, rhs in
+            if lhs.line.startTime != rhs.line.startTime {
+                return lhs.line.startTime < rhs.line.startTime
+            }
+            return lhs.offset < rhs.offset
+        }
+        var sorted = indexedLyrics.map { $0.line }
+
+        // 2. Set endTime to the next DISTINCT timestamp rather than the next line's start time
+        if !sorted.isEmpty {
+            for i in 0..<sorted.count {
+                // Find the first subsequent line that has a strictly greater startTime
+                if let nextDistinctLine = sorted[(i + 1)...].first(where: { $0.startTime > sorted[i].startTime }) {
+                    sorted[i].endTime = nextDistinctLine.startTime
+                } else {
+                    sorted[i].endTime = nil // The last group of lines sharing the same final timestamp keep endTime == nil
+                }
             }
         }
+
         return sorted
     }
     

--- a/Models/Core/Lyrics.swift
+++ b/Models/Core/Lyrics.swift
@@ -81,14 +81,12 @@ extension LyricLine {
         var sorted = indexedLyrics.map { $0.line }
 
         // 2. Set endTime to the next DISTINCT timestamp rather than the next line's start time
-        if !sorted.isEmpty {
-            for i in 0..<sorted.count {
-                // Find the first subsequent line that has a strictly greater startTime
-                if let nextDistinctLine = sorted[(i + 1)...].first(where: { $0.startTime > sorted[i].startTime }) {
-                    sorted[i].endTime = nextDistinctLine.startTime
-                } else {
-                    sorted[i].endTime = nil // The last group of lines sharing the same final timestamp keep endTime == nil
-                }
+        if sorted.count > 1 {
+            sorted[sorted.count - 1].endTime = nil   // final line: no following timestamp
+            for i in stride(from: sorted.count - 2, through: 0, by: -1) {
+                sorted[i].endTime = sorted[i].startTime == sorted[i + 1].startTime
+                    ? sorted[i + 1].endTime      // same timestamp: inherit the group's window
+                    : sorted[i + 1].startTime    // different timestamp: it starts the next group
             }
         }
 

--- a/Views/Main/TrackLyricsView.swift
+++ b/Views/Main/TrackLyricsView.swift
@@ -227,7 +227,7 @@ struct TrackLyricsContent: View {
         guard hasTimedLyrics, !lyricLines.isEmpty else { return }
 
         // Prefer precise judgment via endTime; fall back to startTime ≤ time when endTime is nil
-        let newIndex = lyricLines.lastIndex { line in
+        let newIndex = lyricLines.firstIndex { line in
             if let end = line.endTime {
                 return time >= line.startTime && time < end
             } else {


### PR DESCRIPTION
### Summary
This PR fixes the synced lyrics line highlighting issue for bilingual lyrics sharing the same timestamp.

### Changes
1. **`Models/Core/Lyrics.swift`**:
   - Used stable sorting in `parseLRC` to preserve original line ordering for identical timestamps.
   - Set each line's `endTime` to the next *distinct* timestamp rather than the next line's `startTime`.
2. **`TrackLyricsView.swift`**:
   - Switched `lastIndex` to `firstIndex` in `updateCurrentLine`.

### Testing
Verified with:
- [x] Bilingual `.lrc` files
- [x] Single-language `.lrc` files
- [x] Plain text / untimed lyrics files