### PR TITLE
Fix: pop back to list when re-tapping selected Home sidebar item

### DIFF
--- a/Utilities/Constants.swift
+++ b/Utilities/Constants.swift
@@ -312,6 +312,9 @@ extension Notification.Name {
     
     static let navigateToPlaylists = Notification.Name("navigateToPlaylists")
     static let navigateToInternetRadio = Notification.Name("navigateToInternetRadio")
+    /// Posted when the user taps the already-selected item in the Home sidebar, so
+    /// open detail overlays can pop back to the underlying list.
+    static let homeSidebarItemRetapped = Notification.Name("homeSidebarItemRetapped")
     
     static let playEntityTracks = Notification.Name("playEntityTracks")
     static let playPlaylistTracks = Notification.Name("playPlaylistTracks")

--- a/Views/Home/HomeSidebarView.swift
+++ b/Views/Home/HomeSidebarView.swift
@@ -29,7 +29,14 @@ struct HomeSidebarView: View {
                 items: allItems,
                 selectedItem: $selectedItem,
                 onItemTap: { item in
+                    // Re-tapping the already-selected item assigns an equal value, so
+                    // downstream `.onChange` never fires; announce it explicitly so open
+                    // detail overlays can pop back to the list.
+                    let isRetap = selectedItem?.id == item.id
                     selectedItem = item
+                    if isRetap {
+                        NotificationCenter.default.post(name: .homeSidebarItemRetapped, object: nil)
+                    }
                 },
                 contextMenuItems: { item in
                     createContextMenuItems(for: item)

--- a/Views/Home/HomeView.swift
+++ b/Views/Home/HomeView.swift
@@ -107,6 +107,11 @@ struct HomeView: View {
                     detailRoleCarrier = nil
                 }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .homeSidebarItemRetapped)) { _ in
+            withAnimation(.easeInOut(duration: AnimationDuration.standardDuration)) {
+                homeDetail = nil
+            }
+        }
     }
 
     // MARK: - Discover View


### PR DESCRIPTION
Fixes #360

## What happened?
When a Home tab sidebar item was already selected (e.g. a pinned "Albums" category) and an album detail view was open, clicking the same sidebar item again did nothing. The user had to use the back button to return to the list.

## Why
Re-tapping the already-selected item assigns an equal value to the selection binding (`HomeSidebarItem: Equatable` compares by id), so the `.onChange(of: selectedSidebarItem)` handler in `HomeView` never fires and `homeDetail` is never cleared.

## What this PR does
- Detects a re-tap of the already-selected item in `HomeSidebarView` and posts a new `homeSidebarItemRetapped` notification.
- `HomeView` listens for it and sets `homeDetail = nil`, which pops any open detail overlay back to the underlying list — same as pressing the back button.
- Also covers playlist details opened from Discover, since they use the same `homeDetail` overlay.

## Testing
- Built and ran locally.
- Home tab → pinned Albums → open album → click Albums again → returns to the albums grid.
- Back button still works; switching to a different sidebar item still dismisses the detail view