### PR TITLE
Use `scaledToFill` instead of `aspectRatio` modifier

### DIFF
--- a/Views/Components/ArtistImageSheet.swift
+++ b/Views/Components/ArtistImageSheet.swift
@@ -116,7 +116,7 @@ struct ArtistImageSheet: View {
             if let image = NSImage(data: result.imageData) {
                 Image(nsImage: image)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
                     .frame(width: 108, height: 108)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
                     .overlay(

--- a/Views/Components/TrackViews/StationTableView.swift
+++ b/Views/Components/TrackViews/StationTableView.swift
@@ -309,7 +309,7 @@ struct StationArtworkThumb: View {
             if let image = station.artworkImage {
                 Image(nsImage: image)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } else {
                 RoundedRectangle(cornerRadius: 4)
                     .fill(Color.gray.opacity(0.2))

--- a/Views/Components/TrackViews/TrackListView.swift
+++ b/Views/Components/TrackViews/TrackListView.swift
@@ -413,7 +413,7 @@ private struct TrackListRow: View {
             if let artworkImage {
                 Image(nsImage: artworkImage)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
                     .frame(width: ViewDefaults.listArtworkSize, height: ViewDefaults.listArtworkSize)
                     .clipShape(RoundedRectangle(cornerRadius: 4))
             } else {

--- a/Views/Components/TrackViews/TrackTableView.swift
+++ b/Views/Components/TrackViews/TrackTableView.swift
@@ -597,7 +597,7 @@ private struct TrackTitleCell: View {
                     if let image = artworkImage {
                         Image(nsImage: image)
                             .resizable()
-                            .aspectRatio(contentMode: .fill)
+                            .scaledToFill()
                             .frame(width: ViewDefaults.listArtworkSize, height: ViewDefaults.listArtworkSize)
                             .clipShape(RoundedRectangle(cornerRadius: 4))
                     } else {

--- a/Views/Components/Widgets/ArtworkImageWell.swift
+++ b/Views/Components/Widgets/ArtworkImageWell.swift
@@ -37,7 +37,7 @@ struct ArtworkImageWell: View {
             if let artworkData, let image = NSImage(data: artworkData) {
                 Image(nsImage: image)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
                     .frame(width: side, height: side)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
                     .overlay(alignment: .topTrailing) {

--- a/Views/Home/EntityDetailView.swift
+++ b/Views/Home/EntityDetailView.swift
@@ -189,7 +189,7 @@ struct EntityDetailView: View {
                let nsImage = NSImage(data: artworkData) {
                 Image(nsImage: nsImage)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
                     .frame(width: 120, height: 120)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
                     .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 5)

--- a/Views/Immersive/ImmersiveView.swift
+++ b/Views/Immersive/ImmersiveView.swift
@@ -282,7 +282,7 @@ struct ImmersiveView: View {
             if let image = cachedArtwork {
                 Image(nsImage: image)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } else {
                 Rectangle()
                     .fill(Color.white.opacity(0.08))

--- a/Views/Main/PlayerView.swift
+++ b/Views/Main/PlayerView.swift
@@ -765,7 +765,7 @@ struct AlbumArtworkContent: View {
            let nsImage = NSImage(data: artworkData) {
             Image(nsImage: nsImage)
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .scaledToFill()
                 .frame(width: 76, height: 76)
                 .clipShape(RoundedRectangle(cornerRadius: 5))
         } else {

--- a/Views/Main/TrackDetailView.swift
+++ b/Views/Main/TrackDetailView.swift
@@ -175,7 +175,7 @@ struct TrackDetailView: View {
                let nsImage = NSImage(data: artworkData) {
                 Image(nsImage: nsImage)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
                     .frame(width: 250, height: 250)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                     .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 5)

--- a/Views/MiniPlayer/MiniPlayerView.swift
+++ b/Views/MiniPlayer/MiniPlayerView.swift
@@ -256,7 +256,7 @@ struct MiniPlayerView: View {
             if let image = cachedArtwork {
                 Image(nsImage: image)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
                     .frame(width: side, height: side)
                     .clipped()
             } else {

--- a/Views/Playlists/PlaylistDetailView.swift
+++ b/Views/Playlists/PlaylistDetailView.swift
@@ -175,7 +175,7 @@ struct PlaylistDetailView: View {
                let nsImage = NSImage(data: artworkData) {
                 Image(nsImage: nsImage)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
                     .frame(width: 120, height: 120)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
                     .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 5)

--- a/Views/Settings/AboutTabView.swift
+++ b/Views/Settings/AboutTabView.swift
@@ -45,7 +45,7 @@ struct AboutTabView: View {
             if let appIcon = NSApp.applicationIconImage {
                 Image(nsImage: appIcon)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .frame(width: 128, height: 128)
             } else {
                 Image(systemName: "drop.fill")
@@ -166,7 +166,7 @@ struct AboutTabView: View {
                 Link(destination: url) {
                     Image(imageName)
                         .resizable()
-                        .aspectRatio(contentMode: .fit)
+                        .scaledToFit()
                         .frame(maxHeight: 24)
                 }
             }

--- a/Views/Settings/IntegrationsTabView.swift
+++ b/Views/Settings/IntegrationsTabView.swift
@@ -76,7 +76,7 @@ struct IntegrationsTabView: View {
                     if let avatar = cachedLastFMAvatar {
                         Image(nsImage: avatar)
                             .resizable()
-                            .aspectRatio(contentMode: .fill)
+                            .scaledToFill()
                             .frame(width: 32, height: 32)
                             .clipShape(Circle())
                     } else {


### PR DESCRIPTION
Updates all usages of `.aspectRatio(contentMode: .fill)` to `.scaledToFill()` to fix Swiftlint violations.