### PR TITLE
Sort album tracks by number in Library view

### DIFF
--- a/Views/Components/TrackViews/TrackListView.swift
+++ b/Views/Components/TrackViews/TrackListView.swift
@@ -136,7 +136,7 @@ struct TrackListView: View {
 
         // Entities and playlists follow the sort order handed down by their container.
         if entityID != nil || playlistID != nil {
-            sortedTracks = tracks.sorted(using: sortOrder)
+            sortedTracks = tracks.sorted(using: TrackSortField.expanded(sortOrder))
             return
         }
 
@@ -146,13 +146,13 @@ struct TrackListView: View {
            let field = TrackSortField.from(storageKey: key) {
             let comparator = field.getComparator(ascending: ascending)
             sortOrder = [comparator]
-            sortedTracks = tracks.sorted(using: [comparator])
+            sortedTracks = tracks.sorted(using: TrackSortField.expanded([comparator]))
             return
         }
 
         let defaultComparator = KeyPathComparator(\Track.title, order: .forward)
         sortOrder = [defaultComparator]
-        sortedTracks = tracks.sorted(using: [defaultComparator])
+        sortedTracks = tracks.sorted(using: TrackSortField.expanded([defaultComparator]))
     }
 
     private func performBackgroundSort(with newSortOrder: [KeyPathComparator<Track>]) {
@@ -165,8 +165,9 @@ struct TrackListView: View {
         sortGeneration += 1
         let generation = sortGeneration
         let initialTracks = tracks
+        let comparators = TrackSortField.expanded(newSortOrder)
         Task.detached(priority: .userInitiated) {
-            let sorted = initialTracks.sorted(using: newSortOrder)
+            let sorted = initialTracks.sorted(using: comparators)
             await MainActor.run {
                 guard generation == self.sortGeneration else { return }
                 self.sortedTracks = sorted
@@ -212,7 +213,7 @@ struct TrackListView: View {
         if TrackSortField.detect(from: sortOrder) == .favorite {
             var updated = sortedTracks
             updated[index].isFavorite = updatedTrack.isFavorite
-            sortedTracks = updated.sorted(using: sortOrder)
+            sortedTracks = updated.sorted(using: TrackSortField.expanded(sortOrder))
         } else {
             sortedTracks[index].isFavorite = updatedTrack.isFavorite
         }

--- a/Views/Components/TrackViews/TrackTableOptionsDropdown.swift
+++ b/Views/Components/TrackViews/TrackTableOptionsDropdown.swift
@@ -61,6 +61,46 @@ enum TrackSortField: String, CaseIterable {
         return sortComparators[self] ?? KeyPathComparator(\Track.title, order: ascending ? .forward : .reverse)
     }
 
+    /// Comparators appended after the primary one so tracks that share the primary value
+    /// fall into album order instead of an arbitrary one. Sorting a multi-album artist by
+    /// `Artist` alone leaves their tracks interleaved across releases; year -> album ->
+    /// disc -> track restores the running order within each one.
+    ///
+    /// Tie-breakers stay ascending even when the primary sort is descending: reversing the
+    /// artist list shouldn't also play albums back to front.
+    var tieBreakers: [KeyPathComparator<Track>] {
+        switch self {
+        case .artist, .composer, .genre:
+            return [
+                KeyPathComparator(\Track.year, order: .forward),
+                KeyPathComparator(\Track.album, order: .forward),
+                KeyPathComparator(\Track.sortableDiscNumber, order: .forward),
+                KeyPathComparator(\Track.sortableTrackNumber, order: .forward)
+            ]
+        case .album, .year:
+            return [
+                KeyPathComparator(\Track.sortableDiscNumber, order: .forward),
+                KeyPathComparator(\Track.sortableTrackNumber, order: .forward)
+            ]
+        default:
+            return []
+        }
+    }
+
+    /// Expand a sort order into the full comparator chain the track views sort with.
+    ///
+    /// The primary comparator is carried over untouched, so the table header indicator, the
+    /// dropdown checkmark and the saved preference all keep reading `sortOrder.first`; only
+    /// the tie-breakers for its field are appended. Callers sort with the result and never
+    /// write it back into the `sortOrder` binding.
+    ///
+    /// A caller that already supplied its own chain — `EntityDetailView` hands down disc/track
+    /// album ordering — is passed through untouched; only a lone comparator is expanded.
+    static func expanded(_ sortOrder: [KeyPathComparator<Track>]) -> [KeyPathComparator<Track>] {
+        guard sortOrder.count == 1, let primary = sortOrder.first else { return sortOrder }
+        return [primary] + detect(from: sortOrder).tieBreakers
+    }
+
     /// User-selectable sort fields. Hidden smart-playlist sort keys like play count and
     /// last played remain supported internally, but are omitted because the table has no
     /// matching visible columns for them.

--- a/Views/Components/TrackViews/TrackTableView.swift
+++ b/Views/Components/TrackViews/TrackTableView.swift
@@ -322,7 +322,7 @@ struct TrackTableView: View {
 
         // Follow overridden sort order for entities and playlists
         if entityID != nil || playlistID != nil {
-            sortedTracks = tracks.sorted(using: sortOrder)
+            sortedTracks = tracks.sorted(using: TrackSortField.expanded(sortOrder))
             return
         }
 
@@ -332,13 +332,13 @@ struct TrackTableView: View {
            let field = TrackSortField.from(storageKey: key) {
             let comparator = field.getComparator(ascending: ascending)
             sortOrder = [comparator]
-            sortedTracks = tracks.sorted(using: [comparator])
+            sortedTracks = tracks.sorted(using: TrackSortField.expanded([comparator]))
             return
         }
         
         let defaultComparator = KeyPathComparator(\Track.title, order: .forward)
         sortOrder = [defaultComparator]
-        sortedTracks = tracks.sorted(using: [defaultComparator])
+        sortedTracks = tracks.sorted(using: TrackSortField.expanded([defaultComparator]))
     }
     
     private func handleDoubleTap(on track: Track) {
@@ -386,9 +386,10 @@ struct TrackTableView: View {
         }
 
         let initialTracks = tracks
+        let comparators = TrackSortField.expanded(newSortOrder)
 
         Task.detached(priority: .userInitiated) {
-            let sorted = initialTracks.sorted(using: newSortOrder)
+            let sorted = initialTracks.sorted(using: comparators)
             await MainActor.run {
                 self.sortedTracks = sorted
             }
@@ -498,7 +499,7 @@ struct TrackTableView: View {
             // in-place mutation + sort doesn't trigger proper view refresh on macOS 14/15
             var updatedTracks = sortedTracks
             updatedTracks[index].isFavorite = updatedTrack.isFavorite
-            sortedTracks = updatedTracks.sorted(using: sortOrder)
+            sortedTracks = updatedTracks.sorted(using: TrackSortField.expanded(sortOrder))
         } else {
             sortedTracks[index].isFavorite = updatedTrack.isFavorite
         }


### PR DESCRIPTION
Hi, thank you for developing Petrichor – I've been using it for a few days and it seems to match most of my expectations from a local music player.

This change fixes a quirk that I've been frustrated by, coming from other apps such as Apple Music and Spotify: when displaying entire albums in the `Library` view, sorting by album rendered the album tracks unsorted with regards to their track number (`#`). This implementation solves this by introducing "tie breakers" that are taken into consideration when specific track fields are used for sorting (e.g. per album), resulting in a more natural albums presentation with tracks sorted by their track number.

Disclaimer: this change has been implemented with the assistance of an AI agent – I am not familiar with the Swift language, although I understand the implementation produced by the agent and I confirmed it to work as expected with a local build of the app.
