### PR TITLE
Consolidate release database migrations and harden schema

### DIFF
--- a/Managers/Database/DMCleanup.swift
+++ b/Managers/Database/DMCleanup.swift
@@ -55,67 +55,7 @@ extension DatabaseManager {
             )
             deletedCounts["playlist_tracks"] = Int(db.changesCount)
             
-            // 2. Now clean up main tables using GRDB where possible
-            
-            // Get all artist IDs that are still referenced in track_artists OR album_artists.
-            // Album-only artists (e.g. the canonical "Various Artists" used to anchor
-            // compilations) have no track_artists rows but must not be considered orphaned.
-            let artistsWithTracks = try TrackArtist
-                .select(TrackArtist.Columns.artistId, as: Int64.self)
-                .distinct()
-                .fetchSet(db)
-
-            let artistsWithAlbums = try AlbumArtist
-                .select(AlbumArtist.Columns.artistId, as: Int64.self)
-                .distinct()
-                .fetchSet(db)
-
-            let referencedArtists = artistsWithTracks.union(artistsWithAlbums)
-
-            // Delete artists that have NO references in either junction
-            let allArtistIds = try Artist.select(Artist.Columns.id, as: Int64.self).fetchSet(db)
-            let artistsToDelete = allArtistIds.subtracting(referencedArtists)
-            
-            if !artistsToDelete.isEmpty {
-                let orphanedArtists = try Artist
-                    .filter(artistsToDelete.contains(Artist.Columns.id))
-                    .deleteAll(db)
-                deletedCounts["artists"] = orphanedArtists
-            }
-            
-            // Delete orphaned albums (albums with no tracks)
-            let albumsWithTracks = try Track
-                .select(Track.Columns.albumId, as: Int64?.self)
-                .filter(Track.Columns.albumId != nil)
-                .distinct()
-                .fetchSet(db)
-                .compactMap { $0 }
-            
-            let allAlbumIds = try Album.select(Album.Columns.id, as: Int64.self).fetchSet(db)
-            let albumsToDelete = allAlbumIds.subtracting(albumsWithTracks)
-            
-            if !albumsToDelete.isEmpty {
-                let orphanedAlbums = try Album
-                    .filter(albumsToDelete.contains(Album.Columns.id))
-                    .deleteAll(db)
-                deletedCounts["albums"] = orphanedAlbums
-            }
-            
-            // Delete orphaned genres (genres with no tracks)
-            let genresWithTracks = try TrackGenre
-                .select(TrackGenre.Columns.genreId, as: Int64.self)
-                .distinct()
-                .fetchSet(db)
-            
-            let allGenreIds = try Genre.select(Genre.Columns.id, as: Int64.self).fetchSet(db)
-            let genresToDelete = allGenreIds.subtracting(genresWithTracks)
-            
-            if !genresToDelete.isEmpty {
-                let orphanedGenres = try Genre
-                    .filter(genresToDelete.contains(Genre.Columns.id))
-                    .deleteAll(db)
-                deletedCounts["genres"] = orphanedGenres
-            }
+            deletedCounts.merge(try deleteOrphanedEntities(in: db)) { $0 + $1 }
             
             // 3. Clean up other orphaned data using raw SQL
             
@@ -131,16 +71,7 @@ extension DatabaseManager {
                 deletedCounts["extended_metadata"] = Int(db.changesCount)
             }
             
-            // Delete orphaned pinned items
-            try db.execute(
-                sql: """
-                DELETE FROM pinned_items
-                WHERE (artist_id IS NOT NULL AND artist_id NOT IN (SELECT id FROM artists))
-                   OR (album_id IS NOT NULL AND album_id NOT IN (SELECT id FROM albums))
-                   OR (playlist_id IS NOT NULL AND playlist_id NOT IN (SELECT id FROM playlists))
-                """
-            )
-            deletedCounts["pinned_items"] = Int(db.changesCount)
+            deletedCounts["pinned_items"] = try deleteOrphanedPins(in: db)
             
             // Log cleanup results
             var totalDeleted = 0
@@ -157,86 +88,65 @@ extension DatabaseManager {
         }
     }
     
-    //// Clean up after removing specific tracks
-    func cleanupAfterTrackRemoval(_ trackIds: [Int64]) async throws {
+    /// Remove specific tracks and clean up entities and pins orphaned by them.
+    func cleanupAfterTrackRemoval(_ tracks: [Track]) async throws {
+        let trackIds = tracks.compactMap(\.trackId)
         guard !trackIds.isEmpty else { return }
         
         Logger.info("Cleaning up after removing \(trackIds.count) tracks...")
         
         try await dbQueue.write { db in
-            // Get affected artist and album IDs before deletion
-            let affectedArtistIds = try TrackArtist
-                .filter(trackIds.contains(TrackArtist.Columns.trackId))
-                .select(TrackArtist.Columns.artistId, as: Int64.self)
-                .distinct()
-                .fetchSet(db)
-            
-            let affectedAlbumIds = try Track
-                .filter(trackIds.contains(Track.Columns.trackId))
-                .filter(Track.Columns.albumId != nil)
-                .select(Track.Columns.albumId, as: Int64?.self)
-                .fetchSet(db)
-                .compactMap { $0 }
-            
-            // Get affected genre IDs
-            let affectedGenreIds = try TrackGenre
-                .filter(trackIds.contains(TrackGenre.Columns.trackId))
-                .select(TrackGenre.Columns.genreId, as: Int64.self)
-                .distinct()
-                .fetchSet(db)
-            
-            // Now check if these artists/albums/genres still have other tracks
-            // Artists that still have tracks
-            let artistsWithTracks = try TrackArtist
-                .filter(affectedArtistIds.contains(TrackArtist.Columns.artistId))
-                .filter(!trackIds.contains(TrackArtist.Columns.trackId))
-                .select(TrackArtist.Columns.artistId, as: Int64.self)
-                .distinct()
-                .fetchSet(db)
-            
-            // Delete artists that no longer have tracks
-            let artistsToDelete = Set(affectedArtistIds).subtracting(artistsWithTracks)
-            if !artistsToDelete.isEmpty {
-                let count = try Artist
-                    .filter(artistsToDelete.contains(Artist.Columns.id))
+            var removedTrackCount = 0
+            for start in stride(from: 0, to: trackIds.count, by: 500) {
+                let ids = Array(trackIds[start..<min(start + 500, trackIds.count)])
+                removedTrackCount += try Track
+                    .filter(ids.contains(Track.Columns.trackId))
                     .deleteAll(db)
-                Logger.info("Removed \(count) orphaned artists")
             }
-            
-            // Albums that still have tracks
-            let albumsWithTracks = try Track
-                .filter(affectedAlbumIds.contains(Track.Columns.albumId))
-                .filter(!trackIds.contains(Track.Columns.trackId))
-                .select(Track.Columns.albumId, as: Int64?.self)
-                .distinct()
-                .fetchSet(db)
-                .compactMap { $0 }
-            
-            // Delete albums that no longer have tracks
-            let albumsToDelete = Set(affectedAlbumIds).subtracting(albumsWithTracks)
-            if !albumsToDelete.isEmpty {
-                let count = try Album
-                    .filter(albumsToDelete.contains(Album.Columns.id))
-                    .deleteAll(db)
-                Logger.info("Removed \(count) orphaned albums")
+            Logger.info("Removed \(removedTrackCount) tracks that no longer exist")
+
+            for (table, count) in try deleteOrphanedEntities(in: db) where count > 0 {
+                Logger.info("Removed \(count) orphaned \(table)")
             }
-            
-            // Genres that still have tracks
-            let genresWithTracks = try TrackGenre
-                .filter(affectedGenreIds.contains(TrackGenre.Columns.genreId))
-                .filter(!trackIds.contains(TrackGenre.Columns.trackId))
-                .select(TrackGenre.Columns.genreId, as: Int64.self)
-                .distinct()
-                .fetchSet(db)
-            
-            // Delete genres that no longer have tracks
-            let genresToDelete = Set(affectedGenreIds).subtracting(genresWithTracks)
-            if !genresToDelete.isEmpty {
-                let count = try Genre
-                    .filter(genresToDelete.contains(Genre.Columns.id))
-                    .deleteAll(db)
-                Logger.info("Removed \(count) orphaned genres")
+
+            let removedPinCount = try deleteOrphanedPins(in: db)
+            if removedPinCount > 0 {
+                Logger.info("Removed \(removedPinCount) orphaned pinned items")
             }
         }
+    }
+
+    /// Albums go first because deleting one can make its album-only artists orphaned.
+    private func deleteOrphanedEntities(in db: Database) throws -> [String: Int] {
+        var deletedCounts = [String: Int]()
+
+        try db.execute(sql: "DELETE FROM albums WHERE NOT EXISTS (SELECT 1 FROM tracks WHERE tracks.album_id = albums.id)")
+        deletedCounts["albums"] = Int(db.changesCount)
+
+        try db.execute(
+            sql: """
+            DELETE FROM artists
+            WHERE NOT EXISTS (SELECT 1 FROM track_artists WHERE track_artists.artist_id = artists.id)
+              AND NOT EXISTS (SELECT 1 FROM album_artists WHERE album_artists.artist_id = artists.id)
+            """
+        )
+        deletedCounts["artists"] = Int(db.changesCount)
+
+        try db.execute(sql: "DELETE FROM genres WHERE NOT EXISTS (SELECT 1 FROM track_genres WHERE track_genres.genre_id = genres.id)")
+        deletedCounts["genres"] = Int(db.changesCount)
+
+        return deletedCounts
+    }
+
+    private func deleteOrphanedPins(in db: Database) throws -> Int {
+        try db.execute(
+            sql: """
+            DELETE FROM pinned_items
+            WHERE (artist_id IS NOT NULL AND artist_id NOT IN (SELECT id FROM artists))
+               OR (album_id IS NOT NULL AND album_id NOT IN (SELECT id FROM albums))
+               OR (playlist_id IS NOT NULL AND playlist_id NOT IN (SELECT id FROM playlists))
+            """
+        )
+        return Int(db.changesCount)
     }
 }

--- a/Managers/Database/DMFolders.swift
+++ b/Managers/Database/DMFolders.swift
@@ -629,16 +629,8 @@ extension DatabaseManager {
             }
         }
         
-        // Remove tracks from database
-        try await dbQueue.write { db in
-            for track in tracksToRemove {
-                try track.delete(db)
-                Logger.info("Removed track that no longer exists: \(track.url.lastPathComponent)")
-            }
-        }
-        
-        // Clean up orphaned metadata
-        try await cleanupAfterTrackRemoval(trackIdsToRemove)
+        // Remove tracks and their orphaned metadata in one transaction.
+        try await cleanupAfterTrackRemoval(tracksToRemove)
         
         // Report results to user
         await MainActor.run {

--- a/Managers/Database/DMNormalization.swift
+++ b/Managers/Database/DMNormalization.swift
@@ -305,7 +305,7 @@ extension DatabaseManager {
 
         // Update release year if not set
         if album.releaseYear == nil && !track.year.isEmpty && track.year != "Unknown Year" {
-            if let year = Int(track.year) {
+            if let year = Int(track.year), (1900...2100).contains(year) {
                 album.releaseYear = year
                 needsUpdate = true
             }

--- a/Managers/Database/DMSetup.swift
+++ b/Managers/Database/DMSetup.swift
@@ -461,8 +461,7 @@ extension DatabaseManager {
         try db.createIndexIfNotExists(name: "idx_tracks_compilation", table: "tracks", columns: ["compilation"])
         try db.createIndexIfNotExists(name: "idx_tracks_media_type", table: "tracks", columns: ["media_type"])
 
-        // TODO: Uncomment in next minor release to add filename index for playlist import performance
-        // try db.createIndexIfNotExists(name: "idx_tracks_filename", table: "tracks", columns: ["filename"])
+        try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_tracks_filename_lower ON tracks(LOWER(filename))")
 
         // Duplicate tracking indices
         try db.createIndexIfNotExists(name: "idx_tracks_primary_track_id", table: "tracks", columns: ["primary_track_id"])
@@ -572,9 +571,9 @@ extension DatabaseManager {
             columns: ["last_played"]
         )
         try db.createIndexIfNotExists(
-            name: "idx_playlist_stations_playlist_id",
+            name: "idx_playlist_stations_playlist_position",
             table: "playlist_stations",
-            columns: ["playlist_id"]
+            columns: ["playlist_id", "position"]
         )
         try db.createIndexIfNotExists(
             name: "idx_playlist_stations_station_id",

--- a/Managers/Database/DatabaseMigration.swift
+++ b/Managers/Database/DatabaseMigration.swift
@@ -224,70 +224,76 @@ enum DatabaseMigrator {
             Logger.info("v12_backfill_album_artists: flagged for background album-artist backfill")
         }
 
-        migrator.registerMigration("v13_add_discover_indices") { db in
-            // Discover's Recently Played row scans tracks ordered by last_played_date.
-            // The composite serves the common case (hideDuplicateTracks defaults to
-            // true) as a range scan; the plain index covers the setting being off,
-            // where the leading is_duplicate column can't be constrained.
-            try db.createIndexIfNotExists(
-                name: "idx_tracks_last_played_date",
-                table: "tracks",
-                columns: ["last_played_date"]
-            )
-            try db.createIndexIfNotExists(
-                name: "idx_tracks_duplicate_last_played",
-                table: "tracks",
-                columns: ["is_duplicate", "last_played_date"]
-            )
+        migrator.registerMigration(
+            "v13_add_discover_radio_and_category_pins",
+            merging: ["v13_add_discover_indices", "v14_add_internet_radio", "v15_pin_default_categories"]
+        ) { db, appliedIdentifiers in
+            // v10's plain filename index cannot serve the case-insensitive playlist-import query.
+            try db.execute(sql: "DROP INDEX IF EXISTS idx_tracks_filename")
+            try db.execute(sql: "CREATE INDEX IF NOT EXISTS idx_tracks_filename_lower ON tracks(LOWER(filename))")
 
-            // Fresh Music selects play_count = 0 at random; without this it scans
-            // the whole tracks table.
-            try db.createIndexIfNotExists(
-                name: "idx_tracks_duplicate_play_count",
-                table: "tracks",
-                columns: ["is_duplicate", "play_count"]
-            )
+            if !appliedIdentifiers.contains("v13_add_discover_indices") {
+                // Discover's Recently Played row scans tracks ordered by last_played_date.
+                // The composite serves the common case (hideDuplicateTracks defaults to
+                // true) as a range scan; the plain index covers the setting being off,
+                // where the leading is_duplicate column can't be constrained.
+                try db.createIndexIfNotExists(
+                    name: "idx_tracks_last_played_date",
+                    table: "tracks",
+                    columns: ["last_played_date"]
+                )
+                try db.createIndexIfNotExists(
+                    name: "idx_tracks_duplicate_last_played",
+                    table: "tracks",
+                    columns: ["is_duplicate", "last_played_date"]
+                )
 
-            // Recently Played derives playlists from a pool of track ids;
-            // playlist_tracks was only indexed by playlist_id, forcing a full scan
-            // in that direction.
-            try db.createIndexIfNotExists(
-                name: "idx_playlist_tracks_track_id",
-                table: "playlist_tracks",
-                columns: ["track_id"]
-            )
+                // Fresh Music selects play_count = 0 at random; without this it scans
+                // the whole tracks table.
+                try db.createIndexIfNotExists(
+                    name: "idx_tracks_duplicate_play_count",
+                    table: "tracks",
+                    columns: ["is_duplicate", "play_count"]
+                )
 
-            Logger.info("v13_add_discover_indices migration completed")
-        }
-
-        migrator.registerMigration("v14_add_internet_radio") { db in
-            try DatabaseManager.createInternetRadioTable(in: db)
-            try DatabaseManager.createPlaylistStationsTable(in: db)
-            try DatabaseManager.createInternetRadioIndices(in: db)
-
-            Logger.info("v14_add_internet_radio migration completed")
-        }
-
-        migrator.registerMigration("v15_pin_default_categories") { db in
-            // Existing installs get them at the top, matching a fresh seed; user pins keep their order.
-            let existingCategoryPins = try PinnedItem
-                .filter(PinnedItem.Columns.itemType == PinnedItem.ItemType.category.rawValue)
-                .fetchCount(db)
-
-            guard existingCategoryPins == 0 else {
-                Logger.info("v15_pin_default_categories skipped, category pins already present")
-                return
+                // Recently Played derives playlists from a pool of track ids;
+                // playlist_tracks was only indexed by playlist_id, forcing a full scan
+                // in that direction.
+                try db.createIndexIfNotExists(
+                    name: "idx_playlist_tracks_track_id",
+                    table: "playlist_tracks",
+                    columns: ["track_id"]
+                )
             }
 
-            let offset = DatabaseManager.defaultCategoryPins.count
-            try db.execute(sql: "UPDATE pinned_items SET sort_order = sort_order + \(offset)")
-            try DatabaseManager.insertDefaultCategoryPins(in: db, startingAt: 0)
+            if !appliedIdentifiers.contains("v14_add_internet_radio") {
+                try DatabaseManager.createInternetRadioTable(in: db)
+                try DatabaseManager.createPlaylistStationsTable(in: db)
+            }
 
-            Logger.info("v15_pin_default_categories migration completed")
+            // Pre-release databases used a playlist_id-only index. The composite
+            // still serves that lookup and also avoids sorting collection contents.
+            try db.execute(sql: "DROP INDEX IF EXISTS idx_playlist_stations_playlist_id")
+            try DatabaseManager.createInternetRadioIndices(in: db)
+
+            if !appliedIdentifiers.contains("v15_pin_default_categories") {
+                // Existing installs get them at the top, matching a fresh seed; user pins keep their order.
+                let existingCategoryPins = try PinnedItem
+                    .filter(PinnedItem.Columns.itemType == PinnedItem.ItemType.category.rawValue)
+                    .fetchCount(db)
+
+                if existingCategoryPins == 0 {
+                    let offset = DatabaseManager.defaultCategoryPins.count
+                    try db.execute(sql: "UPDATE pinned_items SET sort_order = sort_order + \(offset)")
+                    try DatabaseManager.insertDefaultCategoryPins(in: db, startingAt: 0)
+                }
+            }
+
+            Logger.info("v13_add_discover_radio_and_category_pins migration completed")
         }
 
         // MARK: - Future Migrations
-        // Add new migrations here as: migrator.registerMigration("v16_description") { db in ... }
+        // Add new migrations here as: migrator.registerMigration("v14_description") { db in ... }
 
         return migrator
     }


### PR DESCRIPTION
- Hardens DB integrity against invalid album years, making track and orphan cleanup atomic and scalable, removing dangling pins/entities.
- Consolidates release DB migrations to include everything towards v1.7 in a single migration for a clean DB ledger.
