### PR TITLE
fix: fetch timed lyrics when only untimed lyrics are available

### DIFF
--- a/Core/LyricsLoader.swift
+++ b/Core/LyricsLoader.swift
@@ -32,11 +32,17 @@ struct LyricsLoader {
             source = .embedded
         }
         
-        // 3. Online lyrics
-        if lines == nil,
+        // 3. Online lyrics (also upgrade untimed lyrics to timed when available)
+        let needsOnlineFetch = lines == nil
+            || (lines != nil && !areLyricsTimed(lines!) && LyricsManager.shared.isOnlineLyricsEnabled)
+        if needsOnlineFetch,
            let fullTrack = fullTrack,
            let databaseManager = databaseManager,
-           let onlineText = await LyricsManager.shared.fetchLyrics(for: fullTrack, using: databaseManager) {
+           let onlineText = await LyricsManager.shared.fetchLyrics(
+               for: fullTrack,
+               using: databaseManager,
+               onlyIfTimed: lines != nil
+           ) {
             lines = parseAnyLyrics(onlineText)
             source = .online
         }
@@ -76,7 +82,12 @@ struct LyricsLoader {
     }
     
     // MARK: - Helpers
-    
+
+    /// Whether the parsed lyrics contain any timed lines (startTime > 0 or endTime set)
+    private static func areLyricsTimed(_ lines: [LyricLine]) -> Bool {
+        lines.contains { $0.startTime > 0 || $0.endTime != nil }
+    }
+
     /// Try to parse as LRC first, then fallback to plain text lines
     private static func parseAnyLyrics(_ raw: String) -> [LyricLine] {
         // Attempt LRC parsing (covers embedded/online that already have timestamps)

--- a/Managers/LyricsManager.swift
+++ b/Managers/LyricsManager.swift
@@ -41,8 +41,9 @@ class LyricsManager {
     /// - Parameters:
     ///   - fullTrack: The full track to fetch lyrics for
     ///   - databaseManager: Database manager for storing fetched lyrics
+    ///   - onlyIfTimed: When true, only store the result if it contains timed lyrics
     /// - Returns: Lyrics text if found, nil otherwise
-    func fetchLyrics(for fullTrack: FullTrack, using databaseManager: DatabaseManager) async -> String? {
+    func fetchLyrics(for fullTrack: FullTrack, using databaseManager: DatabaseManager, onlyIfTimed: Bool = false) async -> String? {
         guard isOnlineLyricsEnabled else {
             Logger.info("LyricsManager: Online lyrics fetching is disabled")
             return nil
@@ -58,6 +59,16 @@ class LyricsManager {
         
         // Try LRCLIB API
         if let lyrics = await fetchFromLRCLIB(fullTrack: fullTrack) {
+            // When onlyIfTimed is set, skip storing untimed results so we don't
+            // overwrite existing untimed embedded lyrics with more untimed lyrics.
+            let parsed = LyricLine.parseLRC(from: lyrics)
+            let hasTimed = parsed.contains { $0.startTime > 0 || $0.endTime != nil }
+
+            if onlyIfTimed && !hasTimed {
+                Logger.info("LyricsManager: Online result is untimed, keeping existing lyrics")
+                return nil
+            }
+
             // Store in database for future use
             await storeLyrics(lyrics, for: fullTrack, using: databaseManager)
             return lyrics

--- a/Views/Settings/IntegrationsTabView.swift
+++ b/Views/Settings/IntegrationsTabView.swift
@@ -189,8 +189,8 @@ struct IntegrationsTabView: View {
 
     private var onlineFeaturesSection: some View {
         Group {
-            Toggle("Fetch lyrics from internet when unavailable", isOn: $onlineLyricsEnabled)
-                .help("Automatically search for lyrics online when no local lyrics are found")
+            Toggle("Fetch timed lyrics from internet when not available", isOn: $onlineLyricsEnabled)
+                .help("Search for synced lyrics online when no local lyrics are found, and upgrade untimed lyrics to timed when available")
 
             Toggle("Fetch artist image and bio from internet", isOn: $artistInfoFetchEnabled)
                 .help("Automatically download artist photos and bios from online sources")


### PR DESCRIPTION
The lyrics waterfall skipped online fetching (Step 3) whenever any lyrics were found, even if they were untimed plain text. This meant tracks with embedded static lyrics never attempted to upgrade to synced LRC lyrics from LRCLIB.

- Add areLyricsTimed() helper to detect untimed lyrics
- Run online fetch when lyrics exist but are untimed and setting is on
- Add onlyIfTimed param to LyricsManager.fetchLyrics() to avoid storing untimed LRCLIB results over embedded untimed lyrics
- Update setting label to reflect the new behavior

Fixes #375